### PR TITLE
refactor: 크롤링 비동기 처리 및 스케줄러 구현

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -22,4 +22,7 @@
       </profile>
     </annotationProcessing>
   </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_STRING" value="-parameters" />
+  </component>
 </project>

--- a/backend/src/main/java/ku_rum/backend/BackendApplication.java
+++ b/backend/src/main/java/ku_rum/backend/BackendApplication.java
@@ -3,8 +3,10 @@ package ku_rum.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/ku_rum/backend/domain/building/domain/repository/BuildingClassRepository.java
+++ b/backend/src/main/java/ku_rum/backend/domain/building/domain/repository/BuildingClassRepository.java
@@ -1,4 +1,4 @@
-package ku_rum.backend.domain.building.repository;
+package ku_rum.backend.domain.building.domain.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;

--- a/backend/src/main/java/ku_rum/backend/domain/building/domain/repository/BuildingRepository.java
+++ b/backend/src/main/java/ku_rum/backend/domain/building/domain/repository/BuildingRepository.java
@@ -1,4 +1,4 @@
-package ku_rum.backend.domain.building.repository;
+package ku_rum.backend.domain.building.domain.repository;
 
 import ku_rum.backend.domain.building.domain.Building;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/backend/src/main/java/ku_rum/backend/domain/building/service/BuildingSearchService.java
+++ b/backend/src/main/java/ku_rum/backend/domain/building/service/BuildingSearchService.java
@@ -1,7 +1,7 @@
 package ku_rum.backend.domain.building.service;
 
 import ku_rum.backend.domain.building.dto.response.BuildingResponse;
-import ku_rum.backend.domain.building.repository.BuildingClassRepository;
+import ku_rum.backend.domain.building.domain.repository.BuildingClassRepository;
 import ku_rum.backend.global.exception.building.BuildingNotFoundException;
 import ku_rum.backend.global.exception.building.BuildingNotRegisteredException;
 import ku_rum.backend.global.response.status.BaseExceptionResponseStatus;
@@ -84,5 +84,13 @@ public class BuildingSearchService {
    */
   private BuildingAbbrev checkMatchWithOriginalName(String name) {
     return BuildingAbbrev.fromOriginalName(name);
+  }
+
+    public String getAbbrevWithoutNumber(String input) {
+      return null;
+    }
+
+  public boolean isValidBuildingAbbrev(String abbrev) {
+      return false;
   }
 }

--- a/backend/src/main/java/ku_rum/backend/domain/notice/application/NoticeService.java
+++ b/backend/src/main/java/ku_rum/backend/domain/notice/application/NoticeService.java
@@ -11,44 +11,65 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class NoticeService {
 
-    @Autowired
     private final NoticeRepository noticeRepository;
 
-    public void crawlAndSaveNotices() {
+    @Qualifier("urlRedisTemplate")
+    private final RedisTemplate<String, String> urlRedisTemplate;
+
+    private static final String NOTICE_REDIS_KEY_PREFIX = "konkuk:notice:";
+
+    @Async
+    @Scheduled(fixedRate = 600000) //10분마다 실행
+    @Transactional
+    public void crawlAndSaveKonkukNotices() {
         WebDriver driver = new ChromeDriver();
 
-        for (NoticeCategory category : NoticeCategory.values()) {
-            String url = category.getUrl();
-            driver.get(url);
+        try {
+            for (NoticeCategory category : NoticeCategory.values()) {
+                String url = category.getUrl();
+                driver.get(url);
+                log.info("크롤링 시작: {}", category.getUrl());
 
-            boolean continueCrawling = true;
-            while (continueCrawling) {
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
+                boolean continueCrawling = true;
+                while (continueCrawling) {
+                    continueCrawling = goToNextButton(category, driver, crawlAndSave(category, driver));
                 }
-
-                continueCrawling = goToNextButton(category, driver, crawling(category, driver, continueCrawling));
             }
+        } finally {
+            driver.quit();
         }
-
-        driver.quit();
     }
 
-    private boolean crawling(NoticeCategory category, WebDriver driver, boolean continueCrawling) {
+    @Transactional
+    protected boolean crawlAndSave(NoticeCategory category, WebDriver driver) {
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+
+        // 페이지가 완전히 로드될 때까지 대기
+        wait.until(ExpectedConditions.presenceOfElementLocated(By.cssSelector(category.getSelector())));
+
         List<WebElement> noticeList = driver.findElements(By.cssSelector(category.getSelector()));
+
+        if (noticeList.isEmpty()) {
+            log.warn("공지사항을 찾지 못했습니다: {}", category.getUrl());
+            return false;
+        }
 
         for (WebElement noticeElement : noticeList) {
             try {
@@ -56,34 +77,40 @@ public class NoticeService {
                 String link = noticeElement.findElement(By.cssSelector("td.td-subject a")).getAttribute("href");
                 String date = noticeElement.findElement(By.cssSelector("td.td-date")).getText();
 
-                Optional<Notice> existingNotice = noticeRepository.findByUrl(link);
-                if (existingNotice.isPresent()) continue;
-
-                // 중요 공지 여부 확인
-                NoticeStatus status = isImportantNotice(noticeElement) ? NoticeStatus.IMPORTANT : NoticeStatus.GENERAL;
-
-                // 크롤링 범위 지정 (작성년도 기준)
-                if (date.startsWith("2024")) {
-                    // Notice 객체 생성 및 저장
-                    Notice notice = Notice.builder()
-                            .url(link)
-                            .title(title)
-                            .date(date)
-                            .noticeCategory(category)
-                            .noticeStatus(status)
-                            .build();
-                    noticeRepository.save(notice);
-                } else {
-                    // 크롤링 종료
-                    continueCrawling = false;
-                    break;
+                // 날짜가 2024년으로 시작하지 않으면 건너뜀 (일단 크롤링 너무 오래걸려서 걸어둠..후에 삭제)
+                if (!date.startsWith("2024")) {
+                    log.info("2024년 공지가 아님: {}", title);
+                    return false;
                 }
+
+                // Redis에 이미 저장된 URL인지 확인
+                String redisKey = NOTICE_REDIS_KEY_PREFIX + link;
+                if (Boolean.TRUE.equals(urlRedisTemplate.hasKey(redisKey))) {
+                    log.info("이미 저장된 공지사항: {}", link);
+                    continue;
+                }
+
+                // 새 공지사항이면 데이터베이스에 저장
+                Notice notice = Notice.builder()
+                        .url(link)
+                        .title(title)
+                        .date(date)
+                        .noticeCategory(category)
+                        .noticeStatus(isImportantNotice(noticeElement) ? NoticeStatus.IMPORTANT : NoticeStatus.GENERAL)
+                        .build();
+
+                log.info("새로운 2024년 공지사항 저장: {}", title);
+                noticeRepository.save(notice);
+                urlRedisTemplate.opsForValue().set(redisKey, link);
+
             } catch (Exception e) {
-                e.printStackTrace();
+                log.error("공지사항 저장 중 오류 발생", e);
             }
         }
-        return continueCrawling;
+        return true;
     }
+
+
 
     private static boolean goToNextButton(NoticeCategory category, WebDriver driver, boolean continueCrawling) {
         try {
@@ -137,4 +164,6 @@ public class NoticeService {
                 .map(NoticeSimpleResponse::new)
                 .toList();
     }
+
+
 }

--- a/backend/src/main/java/ku_rum/backend/domain/notice/application/NoticeService.java
+++ b/backend/src/main/java/ku_rum/backend/domain/notice/application/NoticeService.java
@@ -39,9 +39,10 @@ public class NoticeService {
     @Scheduled(fixedRate = 600000) //10분마다 실행
     @Transactional
     public void crawlAndSaveKonkukNotices() {
-        WebDriver driver = new ChromeDriver();
+        WebDriver driver = null;
 
         try {
+            driver = new ChromeDriver();
             for (NoticeCategory category : NoticeCategory.values()) {
                 String url = category.getUrl();
                 driver.get(url);
@@ -57,8 +58,7 @@ public class NoticeService {
         }
     }
 
-    @Transactional
-    protected boolean crawlAndSave(NoticeCategory category, WebDriver driver) {
+    private boolean crawlAndSave(NoticeCategory category, WebDriver driver) {
         WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
 
         // 페이지가 완전히 로드될 때까지 대기
@@ -91,13 +91,7 @@ public class NoticeService {
                 }
 
                 // 새 공지사항이면 데이터베이스에 저장
-                Notice notice = Notice.builder()
-                        .url(link)
-                        .title(title)
-                        .date(date)
-                        .noticeCategory(category)
-                        .noticeStatus(isImportantNotice(noticeElement) ? NoticeStatus.IMPORTANT : NoticeStatus.GENERAL)
-                        .build();
+                Notice notice = Notice.of(title, link, date, category, isImportantNotice(noticeElement) ? NoticeStatus.IMPORTANT : NoticeStatus.GENERAL);
 
                 log.info("새로운 2024년 공지사항 저장: {}", title);
                 noticeRepository.save(notice);

--- a/backend/src/main/java/ku_rum/backend/domain/notice/domain/Notice.java
+++ b/backend/src/main/java/ku_rum/backend/domain/notice/domain/Notice.java
@@ -39,12 +39,14 @@ public class Notice extends BaseEntity {
         this.noticeStatus = noticeStatus;
     }
 
-    public static Notice of(String title, String url) {
+
+    public static Notice of(String title, String url, String date, NoticeCategory noticeCategory, NoticeStatus noticeStatus) {
         return Notice.builder()
                 .title(title)
                 .url(url)
-                .noticeCategory(NoticeCategory.AFFAIR)
-                .noticeStatus(NoticeStatus.GENERAL)
+                .date(date)
+                .noticeCategory(noticeCategory)
+                .noticeStatus(noticeStatus)
                 .build();
     }
 }

--- a/backend/src/main/java/ku_rum/backend/domain/notice/domain/NoticeCategory.java
+++ b/backend/src/main/java/ku_rum/backend/domain/notice/domain/NoticeCategory.java
@@ -24,7 +24,7 @@ public enum NoticeCategory {
     GENERAL("일반", "https://www.konkuk.ac.kr/konkuk/2244/subview.do",
             "#menu2244_obj1191 > div._fnctWrap > form:nth-child(2) > div > table > tbody > tr", "#menu2244_obj1191 > div._fnctWrap > form:nth-child(3) > div > div > a._listNext"),
 
-    INDUSTRY_ACADEMIC("산학", "https://www.konkuk.ac.kr/konkuk/2244/subview.do",
+    INDUSTRY_ACADEMIC("산학", "https://www.konkuk.ac.kr/konkuk/19329/subview.do",
             "#_combBbs > table > tbody > tr", "#_combBbs > form:nth-child(3) > div > div > a._listNext"),
 
     EMPLOYMENT("채용", "https://www.konkuk.ac.kr/konkuk/19564/subview.do",

--- a/backend/src/main/java/ku_rum/backend/domain/notice/presentation/CrawlingResponse.java
+++ b/backend/src/main/java/ku_rum/backend/domain/notice/presentation/CrawlingResponse.java
@@ -1,0 +1,15 @@
+package ku_rum.backend.domain.notice.presentation;
+
+import lombok.Getter;
+
+@Getter
+public enum CrawlingResponse {
+    START_CRAWLING("크롤링 작업이 시작되었습니다."),
+    CRAWLING_FAIL("크롤링에 실패하였습니다.");
+
+    private final String message;
+
+    CrawlingResponse(String message) {
+        this.message = message;
+    }
+}

--- a/backend/src/main/java/ku_rum/backend/domain/notice/presentation/NoticeController.java
+++ b/backend/src/main/java/ku_rum/backend/domain/notice/presentation/NoticeController.java
@@ -1,7 +1,6 @@
 package ku_rum.backend.domain.notice.presentation;
 
 import ku_rum.backend.domain.notice.application.NoticeService;
-import ku_rum.backend.domain.notice.domain.Notice;
 import ku_rum.backend.domain.notice.domain.NoticeCategory;
 import ku_rum.backend.domain.notice.dto.response.NoticeSimpleResponse;
 import ku_rum.backend.global.response.BaseResponse;
@@ -21,11 +20,17 @@ public class NoticeController {
      * 주어진 조건(작성일 기준)을 만족하는 건국대학교 공지사항을 모두 크롤링
      * @return 성공메시지
      */
-    @PostMapping("/crawl")
-    public BaseResponse<String> crawlNotices() { //redis에 저장해두고 redis에 없으면 db에 저장을 한 (key에다가 공지사항 url링크 저장)
-        noticeService.crawlAndSaveNotices();
-        return BaseResponse.ok("크롤링 및 저장에 성공하였습니다.");
+    @PostMapping("/crawl/konkuk")
+    public BaseResponse<String> crawlKonkukNotices() { //redis에 저장해두고 redis에 없으면 db에 저장을 한 (key에다가 공지사항 url링크 저장)
+        noticeService.crawlAndSaveKonkukNotices();
+        return BaseResponse.ok("크롤링 작업이 시작되었습니다.");
     }
+
+//    @PostMapping("/crawl/saramin")
+//    public BaseResponse<String> crawlSaraminNotices() {
+//        noticeService.crawlAndSaveSaraminNotices();
+//        return BaseResponse.ok("사람인 hot100 크롤링 및 저장에 성공하였습니다.");
+//    }
 
     /**
      * 카테고리별 공지사항 조회

--- a/backend/src/main/java/ku_rum/backend/domain/notice/presentation/NoticeController.java
+++ b/backend/src/main/java/ku_rum/backend/domain/notice/presentation/NoticeController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import static ku_rum.backend.domain.notice.presentation.CrawlingResponse.*;
+
 @RestController
 @RequestMapping("/api/v1/notices")
 @RequiredArgsConstructor
@@ -23,7 +25,7 @@ public class NoticeController {
     @PostMapping("/crawl/konkuk")
     public BaseResponse<String> crawlKonkukNotices() { //redis에 저장해두고 redis에 없으면 db에 저장을 한 (key에다가 공지사항 url링크 저장)
         noticeService.crawlAndSaveKonkukNotices();
-        return BaseResponse.ok("크롤링 작업이 시작되었습니다.");
+        return BaseResponse.ok(START_CRAWLING.getMessage());
     }
 
 //    @PostMapping("/crawl/saramin")

--- a/backend/src/main/java/ku_rum/backend/domain/user/application/MailService.java
+++ b/backend/src/main/java/ku_rum/backend/domain/user/application/MailService.java
@@ -8,6 +8,7 @@ import ku_rum.backend.global.exception.user.DuplicateEmailException;
 import ku_rum.backend.global.exception.user.MailSendException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -29,6 +30,8 @@ import static ku_rum.backend.global.response.status.BaseExceptionResponseStatus.
 public class MailService {
     private final JavaMailSender emailSender;
     private final UserRepository userRepository;
+
+    @Qualifier("stringRedisTemplate")
     private final RedisTemplate<String, String> redisTemplate;
 
     public void sendEmail(String toEmail,

--- a/backend/src/main/java/ku_rum/backend/domain/user/application/UserService.java
+++ b/backend/src/main/java/ku_rum/backend/domain/user/application/UserService.java
@@ -47,7 +47,6 @@ import static ku_rum.backend.domain.user.domain.MailSendSetting.*;
 import static ku_rum.backend.global.config.MailConfig.*;
 import static ku_rum.backend.global.response.status.BaseExceptionResponseStatus.*;
 
-@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor

--- a/backend/src/main/java/ku_rum/backend/domain/user/presentation/UserController.java
+++ b/backend/src/main/java/ku_rum/backend/domain/user/presentation/UserController.java
@@ -33,6 +33,7 @@ public class UserController {
     public BaseResponse<WeinLoginResponse> loginToWein(@RequestBody @Valid WeinLoginRequest weinLoginRequest) {
 //        BaseResponse<WeinLoginResponse> weinLoginResponseBaseResponse = userService.loginToWein(weinLoginRequest);
         return userService.loginToWein(weinLoginRequest);
+    }
 
     @PostMapping("/validations/email")
     public BaseResponse<Void> validateEmail(@RequestBody @Valid final EmailValidationRequest emailValidationRequest) {

--- a/backend/src/main/java/ku_rum/backend/global/config/AsyncConfig.java
+++ b/backend/src/main/java/ku_rum/backend/global/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package ku_rum.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/backend/src/main/java/ku_rum/backend/global/config/RedisConfig.java
+++ b/backend/src/main/java/ku_rum/backend/global/config/RedisConfig.java
@@ -3,6 +3,7 @@ package ku_rum.backend.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -30,5 +31,15 @@ public class RedisConfig {
     redisTemplate.setValueSerializer(new StringRedisSerializer());
     redisTemplate.setConnectionFactory(redisConnectionFactory());
     return redisTemplate;
+  }
+
+  @Bean
+  @Primary
+  public RedisTemplate<String, String> urlRedisTemplate() {
+    RedisTemplate<String, String> urlRedisTemplate = new RedisTemplate<>();
+    urlRedisTemplate.setKeySerializer(new StringRedisSerializer());
+    urlRedisTemplate.setValueSerializer(new StringRedisSerializer());
+    urlRedisTemplate.setConnectionFactory(redisConnectionFactory());
+    return urlRedisTemplate;
   }
 }

--- a/backend/src/test/java/ku_rum/backend/domain/bookmark/domain/BookmarkTest.java
+++ b/backend/src/test/java/ku_rum/backend/domain/bookmark/domain/BookmarkTest.java
@@ -3,6 +3,7 @@ package ku_rum.backend.domain.bookmark.domain;
 import ku_rum.backend.domain.building.domain.Building;
 import ku_rum.backend.domain.department.domain.Department;
 import ku_rum.backend.domain.notice.domain.Notice;
+import ku_rum.backend.domain.notice.domain.NoticeCategory;
 import ku_rum.backend.domain.user.domain.User;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 
+import static ku_rum.backend.domain.notice.domain.NoticeStatus.GENERAL;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -20,7 +22,7 @@ class BookmarkTest {
     void saveBookmarkWithUserAndNotice() {
         //given
         User user = createUser("사용자1", "202112322");
-        Notice notice = Notice.of("가나다라", "naver.com/abc123");
+        Notice notice = Notice.of("가나다라", "naver.com/abc123", "2024-11-07", NoticeCategory.AFFAIR, GENERAL);
 
         //when
         Bookmark bookmark = Bookmark.of(user, notice);

--- a/backend/src/test/java/ku_rum/backend/domain/building/controller/BuildingSearchControllerTest.java
+++ b/backend/src/test/java/ku_rum/backend/domain/building/controller/BuildingSearchControllerTest.java
@@ -1,7 +1,7 @@
 package ku_rum.backend.domain.building.controller;
 
 import ku_rum.backend.common.BaseControllerTest;
-import ku_rum.backend.domain.building.repository.BuildingClassRepository;
+import ku_rum.backend.domain.building.domain.repository.BuildingClassRepository;
 import ku_rum.backend.domain.building.service.BuildingSearchService;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;

--- a/backend/src/test/java/ku_rum/backend/domain/notice/domain/NoticeTest.java
+++ b/backend/src/test/java/ku_rum/backend/domain/notice/domain/NoticeTest.java
@@ -25,7 +25,7 @@ class NoticeTest {
         User user = User.of("사용자1", "미미미누", "password123", "202112322", department);
 
         //when
-        Notice notice = Notice.of("가나다라", "naver.com/abc123");
+        Notice notice = Notice.of("가나다라", "naver.com/abc123", "2024-11-07", NoticeCategory.AFFAIR, GENERAL);
 
         //then
         assertThat(notice.getTitle()).isEqualTo("가나다라");
@@ -42,7 +42,7 @@ class NoticeTest {
         User user = User.of("사용자1", "미미미누", "password123", "202112322", department);
 
         //when
-        Notice notice = Notice.of("가나다라", "naver.com/abc123");
+        Notice notice = Notice.of("가나다라", "naver.com/abc123", "2024-11-07", NoticeCategory.AFFAIR, GENERAL);
 
         //then
         assertThat(notice.getNoticeStatus()).isEqualTo(GENERAL);

--- a/backend/src/test/java/ku_rum/backend/domain/notice/presentation/NoticeControllerTest.java
+++ b/backend/src/test/java/ku_rum/backend/domain/notice/presentation/NoticeControllerTest.java
@@ -9,6 +9,7 @@ import ku_rum.backend.domain.notice.dto.response.NoticeSimpleResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -24,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(NoticeController.class)
+@WebMvcTest(controllers = NoticeController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
 class NoticeControllerTest {
 
     @Autowired
@@ -39,15 +40,15 @@ class NoticeControllerTest {
     @DisplayName("공지사항 크롤링 성공")
     @Test
     void crawlNoticesSuccess() throws Exception {
-        doNothing().when(noticeService).crawlAndSaveNotices();
+        doNothing().when(noticeService).crawlAndSaveKonkukNotices();
 
-        mockMvc.perform(post("/api/v1/notices/crawl")
+        mockMvc.perform(post("/api/v1/notices/crawl/konkuk")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("OK"))
-                .andExpect(jsonPath("$.data").value("크롤링 및 저장에 성공하였습니다."));
+                .andExpect(jsonPath("$.data").value("크롤링 작업이 시작되었습니다."));
     }
 
     @DisplayName("카테고리별 공지사항 조회 성공")

--- a/backend/src/test/java/ku_rum/backend/domain/user/application/UserServiceTest.java
+++ b/backend/src/test/java/ku_rum/backend/domain/user/application/UserServiceTest.java
@@ -1,8 +1,8 @@
 package ku_rum.backend.domain.user.application;
 
 import jakarta.transaction.Transactional;
-import ku_rum.backend.domain.building.repository.BuildingRepository;
 import ku_rum.backend.domain.building.domain.Building;
+import ku_rum.backend.domain.building.domain.repository.BuildingRepository;
 import ku_rum.backend.domain.department.domain.Department;
 import ku_rum.backend.domain.department.domain.repository.DepartmentRepository;
 import ku_rum.backend.domain.user.domain.User;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closed #31 

## 📝작업 내용

- 크롤링을 비동기적으로 처리하기 위해 "@Async"를 사용하였습니다.
- 스케줄러를 구현해놨는데 일단 테스트를 위해 **10분마다 한번씩 2024년에 작성된 공지사항**만 크롤링하도록 구현해둔 상태입니다.
- 추가적으로, 테스트쪽에 오류가 많길래 수정해두었습니다. (building에 대한 테스트코드에서 다음의 메서드가 선언이 안되어있는 사용중인것 같아서 사진과 같이 임시적으로 선언해뒀습니다.)
<img width="500" alt="스크린샷 2024-11-15 오후 5 58 06" src="https://github.com/user-attachments/assets/c5654dc4-f93f-4158-a2b0-8e07dab67c37">
<img width="500" alt="스크린샷 2024-11-15 오후 5 59 59" src="https://github.com/user-attachments/assets/2be4fdc7-ddd0-4529-99b1-772454f22880">

### 스크린샷 (선택)

## 💬리뷰 요구사항

> h2 데이터베이스 테스트를 위하여 임시적으로 applicaiton.yml 파일을 만들어서 설정하고 SecurityConfig도 다음과 같이 수정을 하여 사용하였습니다. 혹시 테스트가 필요한 경우 참고해주세요! (커밋에는 적용하지 않았습니다)

<img width="500" alt="스크린샷 2024-11-15 오후 5 53 06" src="https://github.com/user-attachments/assets/c5f59fcc-8785-44f3-adba-69c6c111f526">
