### PR TITLE
refactor: 로그 파일 분리 (#174)

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -4,14 +4,28 @@
     <timestamp key="ToDay" datePattern="yyyyMMdd" />
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- INFO 로그 허용 -->
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>NEUTRAL</onMismatch>
+        </filter>
+
+        <!-- ERROR 로그 허용 -->
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+
         <layout class="ch.qos.logback.classic.PatternLayout">
-            <Pattern>
-                ${LOG_PATTERN}
-            </Pattern>
+            <Pattern>${LOG_PATTERN}</Pattern>
         </layout>
     </appender>
 
-    <appender name="FILE1" class="ch.qos.logback.core.rolling.RollingFileAppender">
+
+    <!-- INFO 로그 파일 저장 -->
+    <appender name="INFO_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>info</level>
             <onMatch>ACCEPT</onMatch>
@@ -30,9 +44,46 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
-        <appender-ref ref="FILE1" />
-        <appender-ref ref="CONSOLE" />
-    </root>
+    <!-- ERROR 로그 파일 저장 -->
+    <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <file>${LOG_PATH}/error/${ToDay}_error.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/error/%d{yyyyMMdd}_error_%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
 
+    <!-- DEBUG 로그 파일 저장 -->
+    <appender name="DEBUG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>DEBUG</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <file>${LOG_PATH}/debug/${ToDay}_debug.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/debug/%d{yyyyMMdd}_debug_%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="INFO_FILE" />
+        <appender-ref ref="ERROR_FILE" />
+        <appender-ref ref="DEBUG_FILE" />
+    </root>
 </configuration>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closes #174

## 📝작업 내용
로그 파일 설정 (Logback)

info.log, error.log, debug.log 파일을 각각 별도로 저장하는 Logback 설정을 적용.
각 로그 파일에 대한 롤링 정책을 설정하여 파일 크기가 10MB를 넘지 않도록 제한.
Promtail 설정

Promtail을 독립적인 컨테이너로 띄워, 로그를 Loki로 전송하도록 설정.
promtail-config.yml에서 여러 로그 파일(info.log, error.log, debug.log)을 수집하기 위한 경로를 설정.
문제 해결

info.log, error.log와 debug.log를 정상적으로 Loki로 전송

