### PR TITLE
refactor: 메일 서비스 리팩토링 (#191)

### DIFF
--- a/src/main/java/ku_rum/backend/domain/common/mail/application/MailSenderService.java
+++ b/src/main/java/ku_rum/backend/domain/common/mail/application/MailSenderService.java
@@ -1,0 +1,31 @@
+package ku_rum.backend.domain.common.mail.application;
+
+import ku_rum.backend.global.exception.user.MailSendException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.MAIL_SEND_EXCEPTION;
+
+@Service
+@RequiredArgsConstructor
+public class MailSenderService {
+    private final JavaMailSender emailSender;
+
+    public void send(String toEmail, String title, String text) {
+        try {
+            emailSender.send(createEmailForm(toEmail, title, text));
+        } catch (RuntimeException e) {
+            throw new MailSendException(MAIL_SEND_EXCEPTION);
+        }
+    }
+
+    private SimpleMailMessage createEmailForm(String toEmail, String title, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject(title);
+        message.setText(text);
+        return message;
+    }
+}

--- a/src/main/java/ku_rum/backend/domain/common/mail/application/MailService.java
+++ b/src/main/java/ku_rum/backend/domain/common/mail/application/MailService.java
@@ -1,124 +1,54 @@
 package ku_rum.backend.domain.common.mail.application;
 
-import ku_rum.backend.domain.user.domain.repository.UserRepository;
+import ku_rum.backend.domain.common.mail.domain.MailAuth;
+import ku_rum.backend.domain.common.mail.domain.repository.MailAuthRepository;
 import ku_rum.backend.domain.common.mail.dto.request.MailSendRequest;
 import ku_rum.backend.domain.common.mail.dto.request.MailVerificationRequest;
 import ku_rum.backend.domain.common.mail.dto.response.MailVerificationResponse;
-import ku_rum.backend.global.exception.email.DuplicateEmailException;
 import ku_rum.backend.global.exception.user.MailSendException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.mail.SimpleMailMessage;
-import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.time.Duration;
-import java.util.Random;
 
 import static ku_rum.backend.domain.common.mail.domain.MailSendSetting.MAIL_SEND_INFO;
-import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.*;
+import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.INVALID_AUTH_CODE;
 
 @Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MailService {
-    private final JavaMailSender emailSender;
-    private final UserRepository userRepository;
-
-    @Qualifier("stringRedisTemplate")
-    private final RedisTemplate<String, String> redisTemplate;
-
-    public void sendEmail(String toEmail,
-                          String title,
-                          String text) {
-        SimpleMailMessage emailForm = createEmailForm(toEmail, title, text);
-        try {
-            emailSender.send(emailForm);
-        } catch (RuntimeException e) {
-            log.debug("메일 서버에서 메일 전송 중, 오류가 발생했습니다. toEmail: {}, " +
-                    "title: {}, text: {}", toEmail, title, text);
-            throw new MailSendException(MAIL_SEND_EXCEPTION);
-        }
-    }
+    private final MailSenderService mailSenderService;
+    private final MailAuthRepository mailAuthRepository;
 
     @Async
-    public void sendCodeToEmail(final MailSendRequest mailSendRequest) {
-        String title = MAIL_SEND_INFO.getTITLE();
-        String authCode = this.createCode();
+    @Transactional
+    public void sendCodeToEmail(final MailSendRequest request) {
+        deleteByEmail(request);
 
-        sendEmail(mailSendRequest.email(), title, authCode);
-        storeAuthCode(mailSendRequest.email(), authCode);
+        MailAuth mailAuth = MailAuth.create(
+                request.email(),
+                MAIL_SEND_INFO.getCODE_LENGTH());
+
+        mailSenderService.send(request.email(), MAIL_SEND_INFO.getTITLE(), mailAuth.getAuthCode());
+        mailAuthRepository.save(mailAuth, Duration.ofMillis(MAIL_SEND_INFO.getAUTH_EXPIRED_MILLS()));
     }
 
-    public MailVerificationResponse verifiedCode(final MailVerificationRequest mailVerificationRequest) {
-        String email = mailVerificationRequest.email();
-        String authCode = mailVerificationRequest.code();
-
-        validateDuplicateEmail(email);
-        return MailVerificationResponse.of(isValidAuthCode(generateKeyByEmail(email), authCode));
+    private void deleteByEmail(MailSendRequest request) {
+        mailAuthRepository.findByEmail(request.email())
+                .ifPresent(existingMailAuth -> {
+                    mailAuthRepository.deleteByEmail(request.email());
+                });
     }
 
-    private void storeAuthCode(String email, String authCode) {
-        redisTemplate.opsForValue().set(generateKeyByEmail(email),
-                authCode, getAuthCodeExpirationMills());
-    }
+    public void verifyCode(final MailVerificationRequest request) {
+        MailAuth mailAuth = mailAuthRepository.findByEmail(request.email())
+                .orElseThrow(() -> new MailSendException(INVALID_AUTH_CODE));
 
-    private Duration getAuthCodeExpirationMills() {
-        return Duration.ofMillis(MAIL_SEND_INFO.getAUTH_EXPIRED_MILLS());
-    }
-
-    private String generateKeyByEmail(String email) {
-        return MAIL_SEND_INFO.getAUTH_CODE_PREFIX() + email;
-    }
-
-    private String getRedisAuthCode(String key) {
-        return redisTemplate.opsForValue().get(key);
-    }
-
-    private boolean checkExistsValue(String key) {
-        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
-    }
-
-    private boolean isValidAuthCode(String key, String authCode) {
-        return checkExistsValue(key) && getRedisAuthCode(key).equals(authCode);
-    }
-
-    private String createCode() {
-        try {
-            Random random = SecureRandom.getInstanceStrong();
-            StringBuilder builder = new StringBuilder();
-
-            for (int i = 0; i < MAIL_SEND_INFO.getCODE_LENGTH(); i++) {
-                builder.append(random.nextInt(10));
-            }
-            return builder.toString();
-        } catch (NoSuchAlgorithmException e) {
-            log.debug("네자리 난수 생성 시 예외가 발생했습니다.");
-            throw new MailSendException(INVALID_AUTH_CODE_GENERATION);
-        }
-    }
-
-    private SimpleMailMessage createEmailForm(String toEmail,
-                                              String title,
-                                              String text) {
-        SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(toEmail);
-        message.setSubject(title);
-        message.setText(text);
-
-        return message;
-    }
-
-    private void validateDuplicateEmail(final String email) {
-        if (userRepository.existsByEmail(email)) {
-            throw new DuplicateEmailException(DUPLICATE_EMAIL);
-        }
+        mailAuth.isValid(request.code());
     }
 }

--- a/src/main/java/ku_rum/backend/domain/common/mail/domain/MailAuth.java
+++ b/src/main/java/ku_rum/backend/domain/common/mail/domain/MailAuth.java
@@ -1,0 +1,42 @@
+package ku_rum.backend.domain.common.mail.domain;
+
+import ku_rum.backend.global.exception.user.MailSendException;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.INVALID_AUTH_CODE;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MailAuth {
+    private final String email;
+    private final String authCode;
+
+    public static MailAuth create(String email, int codeLength) {
+        return new MailAuth(email, generateCode(codeLength));
+    }
+
+    public static MailAuth of(String email, String authCode) {
+        return new MailAuth(email, authCode);
+    }
+
+    public void isValid(String inputCode) {
+        if (!this.authCode.equals(inputCode)) {
+            throw new MailSendException(INVALID_AUTH_CODE);
+        }
+    }
+
+    private static String generateCode(int length) {
+        SecureRandom random = new SecureRandom();
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            builder.append(random.nextInt(10));
+        }
+        return builder.toString();
+    }
+}

--- a/src/main/java/ku_rum/backend/domain/common/mail/domain/MailSendSetting.java
+++ b/src/main/java/ku_rum/backend/domain/common/mail/domain/MailSendSetting.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MailSendSetting {
     MAIL_SEND_INFO("쿠룸 이메일 인증 번호",
-            4,
+            6,
             "AuthCode ",
             1800000,
             "메일이 성공적으로 전송되었습니다.");

--- a/src/main/java/ku_rum/backend/domain/common/mail/domain/repository/MailAuthRepository.java
+++ b/src/main/java/ku_rum/backend/domain/common/mail/domain/repository/MailAuthRepository.java
@@ -1,0 +1,45 @@
+package ku_rum.backend.domain.common.mail.domain.repository;
+
+import ku_rum.backend.domain.common.mail.domain.MailAuth;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class MailAuthRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void save(MailAuth mailAuth, Duration expiration) {
+        redisTemplate.opsForValue().set(
+                generateKey(mailAuth.getEmail()),
+                mailAuth.getAuthCode(),
+                expiration
+        );
+    }
+
+    public Optional<MailAuth> findByEmail(String email) {
+        String key = generateKey(email);
+        String authCode = redisTemplate.opsForValue().get(key);
+        if (authCode == null) {
+            return Optional.empty();
+        }
+        return Optional.of(MailAuth.of(email, authCode));
+    }
+
+    public void deleteByEmail(String email) {
+        String key = generateKey(email);
+        redisTemplate.delete(key);
+    }
+
+    private String generateKey(String email) {
+        return "MAIL_AUTH:" + email;
+    }
+}

--- a/src/main/java/ku_rum/backend/domain/common/mail/dto/request/MailVerificationRequest.java
+++ b/src/main/java/ku_rum/backend/domain/common/mail/dto/request/MailVerificationRequest.java
@@ -1,8 +1,6 @@
 package ku_rum.backend.domain.common.mail.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.*;
 
 public record MailVerificationRequest(
 
@@ -11,6 +9,7 @@ public record MailVerificationRequest(
         String email,
 
         @NotNull(message = "인증코드 입력은 필수입니다.")
+        @Size(min = 6, max = 6)
         String code) {
 
     public MailVerificationRequest(String email, String code) {

--- a/src/main/java/ku_rum/backend/domain/common/mail/presentation/MailController.java
+++ b/src/main/java/ku_rum/backend/domain/common/mail/presentation/MailController.java
@@ -27,7 +27,8 @@ public class MailController {
 
     @PostMapping("/verification_codes")
     public BaseResponse<MailVerificationResponse> verificationCode(@RequestBody @Valid final MailVerificationRequest mailVerificationRequest) {
-        return BaseResponse.ok(mailService.verifiedCode(mailVerificationRequest));
+        mailService.verifyCode(mailVerificationRequest);
+        return BaseResponse.ok(MailVerificationResponse.of(true));
     }
 
 }

--- a/src/main/java/ku_rum/backend/global/support/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/ku_rum/backend/global/support/status/BaseExceptionResponseStatus.java
@@ -33,12 +33,13 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     DUPLICATE_LOGIN(300, HttpStatus.BAD_REQUEST, "이미 존재하는 아이디입니다."),
     DUPLICATE_STUDENT_ID(301, HttpStatus.BAD_REQUEST, "이미 존재하는 학번입니다."),
     MAIL_SEND_EXCEPTION(302, HttpStatus.INTERNAL_SERVER_ERROR, "인증 메일 전송에 오류가 발생했습니다."),
-    INVALID_AUTH_CODE_GENERATION(303, HttpStatus.INTERNAL_SERVER_ERROR, "인증 번호 4자리 수 생성에 오류가 발생했습니다."),
+    INVALID_AUTH_CODE_GENERATION(303, HttpStatus.INTERNAL_SERVER_ERROR, "인증 번호 6자리 수 생성에 오류가 발생했습니다."),
     NO_SUCH_USER(304, HttpStatus.BAD_REQUEST, "존재하지 않는 사용자입니다."),
     DUPLICATE_EMAIL(305, HttpStatus.BAD_REQUEST, "이미 존재하는 이메일입니다."),
     DUPLICATE_NICKNAME(306, HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
     NO_SUCH_LOGINID(307, HttpStatus.BAD_REQUEST, "존재하지 않는 아이디입니다."),
     INVALID_PASSWORD(308, HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    INVALID_AUTH_CODE(309, HttpStatus.BAD_REQUEST, "메일 코드 인증에 오류가 발생했습니다."),
 
 
     /**

--- a/src/test/java/ku_rum/backend/domain/common/mail/application/MailServiceTest.java
+++ b/src/test/java/ku_rum/backend/domain/common/mail/application/MailServiceTest.java
@@ -1,10 +1,9 @@
 package ku_rum.backend.domain.common.mail.application;
 
+import ku_rum.backend.domain.common.mail.domain.MailAuth;
+import ku_rum.backend.domain.common.mail.domain.repository.MailAuthRepository;
 import ku_rum.backend.domain.common.mail.dto.request.MailSendRequest;
 import ku_rum.backend.domain.common.mail.dto.request.MailVerificationRequest;
-import ku_rum.backend.domain.common.mail.dto.response.MailVerificationResponse;
-import ku_rum.backend.domain.user.domain.repository.UserRepository;
-import ku_rum.backend.global.exception.email.DuplicateEmailException;
 import ku_rum.backend.global.exception.user.MailSendException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,16 +11,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ValueOperations;
-import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MailServiceTest {
@@ -30,68 +30,69 @@ class MailServiceTest {
     private JavaMailSender emailSender;
 
     @Mock
-    private UserRepository userRepository;
+    private MailSenderService mailSenderService;
 
     @Mock
-    private RedisTemplate<String, String> redisTemplate;
-
-    @Mock
-    private ValueOperations<String, String> valueOperations;
+    private MailAuthRepository mailAuthRepository;
 
     @InjectMocks
     private MailService mailService;
 
     @Test
-    @DisplayName("인증을 보낸 이메일이 중복이 아닌 경우 정상 작동된다.")
-    void NonDuplicateEmailCheck() {
+    @DisplayName("이메일 인증 코드 전송 - 성공")
+    void sendCodeToEmail_success() {
         // given
-        String email = "test@example.com";
-        doThrow(new RuntimeException()).when(emailSender).send(any(SimpleMailMessage.class));
+        MailSendRequest request = new MailSendRequest("test@example.com");
+        MailAuth mailAuth = MailAuth.create(request.email(), 6);
 
-        // when & then
-        assertThatThrownBy(() -> mailService.sendCodeToEmail(new MailSendRequest(email)))
-                .isInstanceOf(MailSendException.class);
+        // when
+        mailService.sendCodeToEmail(request);
+
+        // then
+        verify(mailSenderService, times(1)).send(eq(request.email()), anyString(), anyString());
+        verify(mailAuthRepository, times(1)).save(any(MailAuth.class), any(Duration.class));
     }
 
     @Test
     @DisplayName("이메일 인증 코드 검증 - 성공")
-    void codeVerifySuccess() {
+    void verifyCode_success() {
         // given
         String email = "test@example.com";
-        String authCode = "123456";
-        String key = "auth_code:" + email;
+        String validCode = "123456";
+        MailVerificationRequest request = new MailVerificationRequest(email, validCode);
+        MailAuth mailAuth = MailAuth.of(email, validCode);
 
-        when(userRepository.existsByEmail(email)).thenReturn(false);
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-        when(valueOperations.get(any())).thenReturn(authCode);
-        when(redisTemplate.hasKey(any())).thenReturn(true);
+        given(mailAuthRepository.findByEmail(email)).willReturn(Optional.of(mailAuth));
 
-        mailService.sendCodeToEmail(new MailSendRequest(email));
-
-        // when
-        MailVerificationResponse response = mailService.verifiedCode(new MailVerificationRequest(email, authCode));
-
-        // then
-        assertThat(response.isVerified()).isTrue();
+        // when & then
+        assertDoesNotThrow(() -> mailService.verifyCode(request));
     }
 
     @Test
-    @DisplayName("이메일 인증 코드 검증 - 실패")
-    void codeVerifyFailure() {
+    @DisplayName("이메일 인증 코드 검증 - 실패 (잘못된 코드)")
+    void verifyCode_invalidCode_fail() {
         // given
         String email = "test@example.com";
-        String wrongAuthCode = "654321";
-        String key = "auth_code:" + email;
+        String invalidCode = "999999";
+        MailVerificationRequest request = new MailVerificationRequest(email, invalidCode);
+        MailAuth mailAuth = MailAuth.of(email, "123456");
 
-        when(userRepository.existsByEmail(email)).thenReturn(false);
-        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
-        when(valueOperations.get(any())).thenReturn("123456");
-        when(redisTemplate.hasKey(any())).thenReturn(true);
+        given(mailAuthRepository.findByEmail(email)).willReturn(Optional.of(mailAuth));
 
-        // when
-        MailVerificationResponse response = mailService.verifiedCode(new MailVerificationRequest(email, wrongAuthCode));
+        // when & then
+        assertThrows(MailSendException.class, () -> mailService.verifyCode(request));
+    }
 
-        // then
-        assertThat(response.isVerified()).isFalse();
+    @Test
+    @DisplayName("이메일 인증 코드 검증 - 실패 (인증 코드 없음)")
+    void verifyCode_notFound_fail() {
+        // given
+        String email = "test@example.com";
+        MailVerificationRequest request = new MailVerificationRequest(email, "123456");
+
+        given(mailAuthRepository.findByEmail(email)).willReturn(Optional.empty());
+
+        // when & then
+        assertThrows(MailSendException.class, () -> mailService.verifyCode(request));
     }
 }

--- a/src/test/java/ku_rum/backend/domain/common/mail/presentation/MailControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/common/mail/presentation/MailControllerTest.java
@@ -52,25 +52,25 @@ class MailControllerTest extends RestDocsTestSupport {
                                         .tag("메일 API")
                                         .description("이메일 인증 요청")
                                         .requestFields(
-                                fieldWithPath("email")
-                                        .type(JsonType.STRING)
-                                        .description("건국대학교 웹메일")
-                                        .attributes(constraints("이메일의 끝자리는 @konkuk.ac.kr로 끝나야 합니다."))
-                        )
+                                                fieldWithPath("email")
+                                                        .type(JsonType.STRING)
+                                                        .description("건국대학교 웹메일")
+                                                        .attributes(constraints("이메일 형식을 지켜야 합니다."))
+                                        )
                                         .responseFields(
-                                fieldWithPath("code")
-                                        .type(JsonType.STRING)
-                                        .description("성공시 반환 코드 (200)"),
-                                fieldWithPath("status")
-                                        .type(JsonType.STRING)
-                                        .description("성공시 상태 값 (OK)"),
-                                fieldWithPath("message")
-                                        .type(JsonType.STRING)
-                                        .description("성공 시 메시지 (OK)"),
-                                fieldWithPath("data")
-                                        .type(JsonType.STRING)
-                                        .description("성공 시 '메일이 성공적으로 전송되었습니다.' 반환합니다.")
-                        ).build())));
+                                                fieldWithPath("code")
+                                                        .type(JsonType.STRING)
+                                                        .description("성공시 반환 코드 (200)"),
+                                                fieldWithPath("status")
+                                                        .type(JsonType.STRING)
+                                                        .description("성공시 상태 값 (OK)"),
+                                                fieldWithPath("message")
+                                                        .type(JsonType.STRING)
+                                                        .description("성공 시 메시지 (OK)"),
+                                                fieldWithPath("data")
+                                                        .type(JsonType.STRING)
+                                                        .description("성공 시 '메일이 성공적으로 전송되었습니다.' 반환합니다.")
+                                        ).build())));
     }
 
     @DisplayName("이메일 인증 코드를 검증한다.")
@@ -78,7 +78,7 @@ class MailControllerTest extends RestDocsTestSupport {
     @WithMockUser
     void verificationCode() throws Exception {
         //given
-        MailVerificationRequest mailVerificationRequest = new MailVerificationRequest("kmw10693@naver.com", "1234");
+        MailVerificationRequest mailVerificationRequest = new MailVerificationRequest("kmw10693@naver.com", "123456");
 
         //when then
         mockMvc.perform(post("/api/v1/mails/verification_codes")
@@ -90,31 +90,35 @@ class MailControllerTest extends RestDocsTestSupport {
                 .andExpect(jsonPath("$.code").value("200"))
                 .andExpect(jsonPath("$.status").value("OK"))
                 .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data.verified").value(true))
                 .andDo(restDocs.document(
                         resource(
                                 ResourceSnippetParameters.builder()
                                         .tag("메일 API")
                                         .description("이메일 인증 코드 검증")
                                         .requestFields(
-                                fieldWithPath("email")
-                                        .type(JsonType.STRING)
-                                        .description("건국대학교 웹메일")
-                                        .attributes(constraints("이메일의 끝자리는 @konkuk.ac.kr로 끝나야 합니다.")),
-                                fieldWithPath("code")
-                                        .type(JsonType.STRING)
-                                        .description("건국대학교 웹메일")
-                                        .attributes(constraints("사용자가 받은 인증코드를 입력받습니다."))
-                        )
+                                                fieldWithPath("email")
+                                                        .type(JsonType.STRING)
+                                                        .description("건국대학교 웹메일")
+                                                        .attributes(constraints("이메일 형식을 지켜야 합니다.")),
+                                                fieldWithPath("code")
+                                                        .type(JsonType.STRING)
+                                                        .description("건국대학교 웹메일")
+                                                        .attributes(constraints("사용자가 받은 인증코드를 입력받습니다."))
+                                        )
                                         .responseFields(
-                                fieldWithPath("code")
-                                        .type(JsonType.NUMBER)
-                                        .description("성공시 반환 코드 (200)"),
-                                fieldWithPath("status")
-                                        .type(JsonType.STRING)
-                                        .description("올바른 인증코드 시 상태 값 (OK)"),
-                                fieldWithPath("message")
-                                        .type(JsonType.STRING)
-                                        .description("올바른 인증코드 시 메시지 (OK)")
-                        ).build())));
+                                                fieldWithPath("code")
+                                                        .type(JsonType.NUMBER)
+                                                        .description("성공시 반환 코드 (200)"),
+                                                fieldWithPath("status")
+                                                        .type(JsonType.STRING)
+                                                        .description("올바른 인증코드 시 상태 값 (OK)"),
+                                                fieldWithPath("message")
+                                                        .type(JsonType.STRING)
+                                                        .description("올바른 인증코드 시 메시지 (OK)"),
+                                                fieldWithPath("data.verified")
+                                                        .type(JsonType.BOOLEAN)
+                                                        .description("인증 성공 여부")
+                                        ).build())));
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closes #191 

## 📝작업 내용
- [x] 메일 인증코드를 4자리에서 6자리로 변경했습니다.
- [x] 도메인 중심 구조로 변경했습니다.
<img width="315" alt="image" src="https://github.com/user-attachments/assets/dc6bd07c-aee8-4dd6-950f-6f42705f098d" />

메일 보내는 로직 - MailSenderService
메일 주요 로직 - MailService

메일 저장소(레디스) - MailAuthRepository
도메인 - DomainAuth