### PR TITLE
최신 공지사항 5개 반환 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,7 @@ dependencies {
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation 'com.mysql:mysql-connector-j'
 
 	// Mail Service
 	implementation 'org.springframework.boot:spring-boot-starter-mail'

--- a/src/main/java/ku_rum/backend/BackendApplication.java
+++ b/src/main/java/ku_rum/backend/BackendApplication.java
@@ -1,6 +1,5 @@
 package ku_rum.backend;
 
-import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -8,7 +7,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
-@EnableBatchProcessing
 @EnableAsync
 public class BackendApplication {
 

--- a/src/main/java/ku_rum/backend/domain/common/image/application/ImageStorageService.java
+++ b/src/main/java/ku_rum/backend/domain/common/image/application/ImageStorageService.java
@@ -1,3 +1,4 @@
+/*
 package ku_rum.backend.domain.common.image.application;
 
 import com.amazonaws.HttpMethod;
@@ -60,3 +61,4 @@ public class ImageStorageService {
         return presignedUrl.split("\\?")[0];
     }
 }
+*/

--- a/src/main/java/ku_rum/backend/domain/common/image/presentation/ImageController.java
+++ b/src/main/java/ku_rum/backend/domain/common/image/presentation/ImageController.java
@@ -1,3 +1,4 @@
+/*
 package ku_rum.backend.domain.common.image.presentation;
 
 import ku_rum.backend.domain.common.image.application.ImageStorageService;
@@ -21,3 +22,4 @@ public class ImageController {
         return BaseResponse.ok(imageStorageService.getPresignedUrl(fileName));
     }
 }
+*/

--- a/src/main/java/ku_rum/backend/domain/notice/application/NoticeSchedule.java
+++ b/src/main/java/ku_rum/backend/domain/notice/application/NoticeSchedule.java
@@ -1,0 +1,22 @@
+/*
+package ku_rum.backend.domain.notice.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NoticeSchedule {
+
+    private final ViewCountService viewCountService;
+    private final NoticeService noticeService;
+
+    @Scheduled(fixedRate = 90000) // 1.5분마다 실행 테스트
+    public void syncViewCountsToDatabaseScheduled() {
+        viewCountService.syncViewCountsToDatabase();
+    }
+
+}
+
+*/

--- a/src/main/java/ku_rum/backend/domain/notice/application/NoticeService.java
+++ b/src/main/java/ku_rum/backend/domain/notice/application/NoticeService.java
@@ -99,4 +99,12 @@ public class NoticeService {
         }
     }
 
+    public List<NoticeSimpleResponse> getRecent5Notices() {
+        List<Notice> noticeList = noticeRepository.findByCreatedAtDesc(PageRequest.of(0, 5));
+
+        return noticeList.stream()
+                .map(e -> new NoticeSimpleResponse(e))
+                .toList();
+    }
+
 }

--- a/src/main/java/ku_rum/backend/domain/notice/application/ViewCountService.java
+++ b/src/main/java/ku_rum/backend/domain/notice/application/ViewCountService.java
@@ -1,0 +1,167 @@
+/*
+package ku_rum.backend.domain.notice.application;
+
+import ku_rum.backend.domain.notice.domain.repository.NoticeRepository;
+import ku_rum.backend.global.exception.notice.RedisSynchronizationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.SYNCHORNIZATION_ERROR;
+
+
+@Service
+@Slf4j
+public class ViewCountService {
+    private static final String NORMAL_VIEW_COUNT_KEY = "notice:viewcount:";
+    private static final String POPULAR_VIEW_COUNT_KEY = "popular:notices";
+    private static final String LOCK_QUEUE_KEY = "lock:viewcount:queue";
+
+    private final RedissonClient redissonClient;
+    private final NoticeRepository noticeRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public ViewCountService(
+            RedissonClient redissonClient,
+            NoticeRepository noticeRepository,
+            @Qualifier("urlRedisTemplate") RedisTemplate<String, String> redisTemplate) {
+        this.redissonClient = redissonClient;
+        this.noticeRepository = noticeRepository;
+        this.redisTemplate = redisTemplate;
+    }
+
+     * 조회수 증가 요청 큐에 추가
+
+
+    public void enqueueLockRequest(String url) {
+        redisTemplate.opsForList().leftPush(LOCK_QUEUE_KEY, url);
+        processQueue();
+    }
+
+*
+     * url에 대해 조회수 redis에 갱신
+
+
+    public void processQueue() {
+        String url = redisTemplate.opsForList().rightPop(LOCK_QUEUE_KEY);
+        if (url != null) {
+            handleLockRequest(url);
+        }
+    }
+
+*
+     * 큐에서 꺼낸 작업을 처리하는 메소드
+
+
+    private void handleLockRequest(String url) {
+        String lockKey = NORMAL_VIEW_COUNT_KEY + url;
+        RLock lock = redissonClient.getLock(lockKey);
+
+        log.info("[handleLockRequest]");
+        try {
+            if (lock.tryLock(3, 1, TimeUnit.SECONDS)) {
+                log.info("락 획득");
+                try {
+                    //일반 조회수 증가
+                    redisTemplate.opsForValue().increment(lockKey);
+                    //인기공지 조회수 증가 - 1)
+                    increasePopularViewCount(url);
+                    //TTL 설정 - 2)
+                    makeTTLonViewedUrl(lockKey);
+
+                } finally {
+                    lock.unlock();
+                    log.info("락 릴리즈");
+                }
+            } else {
+                //락을 획득하지 못했을 경우 큐에 재시도할 수 있도록 넣기
+                enqueueLockRequest(url);
+            }
+        } catch (InterruptedException e) {
+            throw new RedisSynchronizationException(SYNCHORNIZATION_ERROR);
+        }
+    }
+
+
+*
+     * 1) 인기공지 조회수 증가
+
+
+    private void increasePopularViewCount(String url) {
+        redisTemplate.opsForZSet().incrementScore(POPULAR_VIEW_COUNT_KEY, url, 1);
+    }
+
+*
+     * 2) 일반 조회수 TTL 설정
+
+
+    private void makeTTLonViewedUrl(String lockKey) {
+        //TTL 설정 전에 기존 값이 존재하는지 확인
+        if (redisTemplate.getExpire(lockKey) == -1) {
+            redisTemplate.expire(lockKey, 2, TimeUnit.HOURS); // 2시간 TTL 설정
+        }
+    }
+
+*
+     * redis의 조회수 정보 db와 동기화
+
+
+    @Transactional
+    public void syncViewCountsToDatabase() {
+        log.info("[syncViewCountsToDatabase] 레디스에 저장된 정보 db에 동기화");
+
+        //redis에서 모든 viewcount 키 조회
+        Set<String> viewCountKeys = redisTemplate.keys(NORMAL_VIEW_COUNT_KEY + "*");
+        if (!viewCountKeys.isEmpty()) {
+            for (String key : viewCountKeys) {
+                try {
+                    //URL 추출 (키 형식: notice:viewcount:url)
+                    String url = key.substring(NORMAL_VIEW_COUNT_KEY.length());
+                    //redis에서 현재 조회수 가져오기
+                    String countStr = redisTemplate.opsForValue().get(key);
+                    if (countStr == null) continue;
+
+                    long count = Long.parseLong(countStr);
+                    //db에 업데이트
+                    noticeRepository.updateViewCount(url, count);
+                    //동기화 후 redis에서 해당 키 삭제
+                    redisTemplate.delete(key);
+                } catch (Exception e) {
+                    throw new RedisSynchronizationException(SYNCHORNIZATION_ERROR);
+                }
+            }
+            log.info("[syncViewCountsToDatabase] <완료> 레디스에 저장된 정보 db에 동기화 ");
+        } else {
+            log.info("[syncViewCountsToDatabase] <미실행> 동기화할 레디스 키가 없습니다.");
+        }
+    }
+
+*
+     * 인기 공지 top 3개 반환
+     * @return
+
+
+    public List<String> mostViewedNotices() {
+        Set<String> topNotices = redisTemplate.opsForZSet()
+                .reverseRange(POPULAR_VIEW_COUNT_KEY, 0, 2); //상위 3개
+
+        return topNotices.stream()
+                .map(noticeRepository::findTitleByUrl)
+                .filter(title -> title != null)
+                .collect(Collectors.toList());
+    }
+
+
+}
+*/

--- a/src/main/java/ku_rum/backend/domain/notice/domain/repository/NoticeRepository.java
+++ b/src/main/java/ku_rum/backend/domain/notice/domain/repository/NoticeRepository.java
@@ -2,6 +2,7 @@ package ku_rum.backend.domain.notice.domain.repository;
 
 import ku_rum.backend.domain.notice.domain.Notice;
 import ku_rum.backend.domain.notice.domain.NoticeCategory;
+import ku_rum.backend.domain.notice.dto.response.NoticeSimpleResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -24,4 +25,8 @@ public interface NoticeRepository extends JpaRepository<Notice, String>, NoticeR
     Optional<Notice> findByUrl(String link);
 
     boolean existsByUrl(String url);
+
+    @Query("SELECT n FROM Notice n ORDER BY n.createdAt DESC")
+    List<Notice> findByCreatedAtDesc(Pageable pageable);
+
 }

--- a/src/main/java/ku_rum/backend/domain/notice/domain/value/ViewCount.java
+++ b/src/main/java/ku_rum/backend/domain/notice/domain/value/ViewCount.java
@@ -1,0 +1,33 @@
+/*
+package ku_rum.backend.domain.notice.domain.value;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import ku_rum.backend.global.exception.notice.InvalidViewCountException;
+import lombok.NoArgsConstructor;
+
+import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.BELOW_ZERO;
+
+@Embeddable
+@NoArgsConstructor
+public class ViewCount {
+
+    @Column(name = "view_count", nullable = false)
+    private long count;
+
+    public ViewCount(long count){
+        if (count < 0){
+            throw new InvalidViewCountException(BELOW_ZERO);
+        }
+        this.count = count;
+    }
+
+    public ViewCount increment() {
+        return new ViewCount(count+1);
+    }
+
+    public long getCount(){
+        return count;
+    }
+}
+*/

--- a/src/main/java/ku_rum/backend/domain/notice/domain/value/converter/ViewCountConverter.java
+++ b/src/main/java/ku_rum/backend/domain/notice/domain/value/converter/ViewCountConverter.java
@@ -1,0 +1,20 @@
+/*
+package ku_rum.backend.domain.notice.domain.value.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import ku_rum.backend.domain.notice.domain.value.ViewCount;
+
+@Converter(autoApply = true)
+public class ViewCountConverter implements AttributeConverter<ViewCount, Long> {
+    @Override
+    public Long convertToDatabaseColumn(ViewCount attribute) {
+        return attribute == null ? 0 : attribute.getCount();
+    }
+
+    @Override
+    public ViewCount convertToEntityAttribute(Long dbData) {
+        return dbData == null ? new ViewCount(0) : new ViewCount(dbData);
+    }
+}
+*/

--- a/src/main/java/ku_rum/backend/domain/notice/dto/response/RecentSearchTermResponse.java
+++ b/src/main/java/ku_rum/backend/domain/notice/dto/response/RecentSearchTermResponse.java
@@ -1,0 +1,13 @@
+package ku_rum.backend.domain.notice.dto.response;
+
+import java.util.List;
+
+public record RecentSearchTermResponse(
+        Long userId,
+        List<String> searchedList
+) {
+
+    public static RecentSearchTermResponse of(Long userId, List<String> searchedList) {
+        return new RecentSearchTermResponse(userId, searchedList);
+    }
+}

--- a/src/main/java/ku_rum/backend/domain/notice/dto/response/ViewCountResponse.java
+++ b/src/main/java/ku_rum/backend/domain/notice/dto/response/ViewCountResponse.java
@@ -1,0 +1,10 @@
+package ku_rum.backend.domain.notice.dto.response;
+
+public record ViewCountResponse(
+        String url,
+        Long count
+) {
+    public static ViewCountResponse of(String url, Long count) {
+        return new ViewCountResponse(url, count);
+    }
+}

--- a/src/main/java/ku_rum/backend/domain/notice/presentation/NoticeRecentController.java
+++ b/src/main/java/ku_rum/backend/domain/notice/presentation/NoticeRecentController.java
@@ -1,6 +1,7 @@
 package ku_rum.backend.domain.notice.presentation;
 
 import ku_rum.backend.domain.notice.application.NoticeService;
+import ku_rum.backend.domain.notice.dto.response.NoticeSimpleResponse;
 import ku_rum.backend.domain.notice.dto.response.RecentSearchTerm;
 import ku_rum.backend.global.security.CustomUserDetails;
 import ku_rum.backend.global.support.response.BaseResponse;
@@ -9,6 +10,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/notices")
@@ -26,5 +29,14 @@ public class NoticeRecentController {
     public BaseResponse<RecentSearchTerm> searchTerms(@AuthenticationPrincipal CustomUserDetails userDetails){
         Long userId = userDetails.getUserId();
         return BaseResponse.ok(noticeService.getRecentSearchTerms(userId));
+    }
+
+    /**
+     * 최근 공지사항 5개 반환
+     * @return
+     */
+    @GetMapping("/recent/5notices")
+    public BaseResponse<List<NoticeSimpleResponse>> recent5Notices(){
+        return BaseResponse.ok(noticeService.getRecent5Notices());
     }
 }

--- a/src/main/java/ku_rum/backend/domain/notice/presentation/NoticeViewCountController.java
+++ b/src/main/java/ku_rum/backend/domain/notice/presentation/NoticeViewCountController.java
@@ -1,0 +1,49 @@
+/*
+package ku_rum.backend.domain.notice.presentation;
+
+import ku_rum.backend.domain.notice.application.ViewCountService;
+import ku_rum.backend.global.security.CustomUserDetails;
+import ku_rum.backend.global.support.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/notices")
+@RequiredArgsConstructor
+public class NoticeViewCountController {
+    private final ViewCountService viewCountService;
+
+    */
+/**
+     * 공지사항 조회수 증가
+     * @param url
+     * @return
+     *//*
+
+    @GetMapping("/url")
+    public BaseResponse<String> increaseViewCount(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                         @RequestParam(name = "url") String url) {
+        viewCountService.enqueueLockRequest(url);
+        return BaseResponse.ok(url + "에 대해 조회수가 증가되었습니다.");
+    }
+
+    */
+/**
+     * 인기 공지사항 제목 반환
+     * @param userDetails
+     * @return
+     *//*
+
+    @GetMapping("/popular/url")
+    public BaseResponse<List<String>> mostViewedNotices(@AuthenticationPrincipal CustomUserDetails userDetails){
+        return BaseResponse.ok(viewCountService.mostViewedNotices());
+    }
+
+}
+*/

--- a/src/main/java/ku_rum/backend/domain/user/presentation/UserProfileController.java
+++ b/src/main/java/ku_rum/backend/domain/user/presentation/UserProfileController.java
@@ -1,3 +1,4 @@
+/*
 package ku_rum.backend.domain.user.presentation;
 
 import jakarta.validation.Valid;
@@ -26,60 +27,71 @@ public class UserProfileController {
     private final UserService userService;
     private final ImageStorageService imageStorageService;
 
-    /**
+    */
+/**
      * 프로필 변경 API
      *
      * @param profileChangeRequest
      * @return
-     */
+     *//*
+
     @PatchMapping("/profile")
     public BaseResponse<String> setProfile(@RequestBody @Valid final ProfileChangeRequest profileChangeRequest) {
         userService.changeProfile(profileChangeRequest);
         return BaseResponse.ok(SUCCESS_PROFILE_SET.getMessage());
     }
 
-    /**
+    */
+/**
      * 이메일로 아이디 가져오기 API
      *
      * @param email
      * @return
-     */
+     *//*
+
     @GetMapping("/loginId")
     public BaseResponse<LoginIdResponse> getLoginId(@RequestParam("email") final String email) {
         return BaseResponse.ok(userService.getLoginId(email));
     }
 
-    /**
+    */
+/**
      * 닉네임 변경 API
      *
      * @return
-     */
+     *//*
+
     @PatchMapping("/nickname")
     public BaseResponse<String> setProfile(@RequestBody @Valid final NicknameChangeRequest nicknameChangeRequest) {
         userService.changeNickname(nicknameChangeRequest);
         return BaseResponse.ok(SUCCESS_CHANGE_NICKNAME.getMessage());
     }
 
-    /**
+    */
+/**
      * 로그인 전 아이디로 비밀번호 초기화 API
      *
      * @param initiatePasswordResetRequest
      * @return
-     */
+     *//*
+
     @PostMapping("/password-reset/initiate")
     public BaseResponse<String> initiatePasswordReset(@RequestBody @Valid final InitiatePasswordResetRequest initiatePasswordResetRequest) {
         userService.initiatePasswordReset(initiatePasswordResetRequest);
         return BaseResponse.ok(SUCCESS_RESET_PASSWORD.getMessage());
     }
 
-    /**
+    */
+/**
      * 로그인 후 아이디로 비밀번호 초기화 API
      *
      * @return
-     */
+     *//*
+
     @PostMapping("/password-reset")
     public BaseResponse<String> resetPassword(@RequestBody @Valid final ResetPasswordRequest resetPasswordRequest) {
         userService.resetPassword(resetPasswordRequest);
         return BaseResponse.ok(SUCCESS_RESET_PASSWORD.getMessage());
     }
 }
+*/

--- a/src/main/java/ku_rum/backend/global/batch/BatchScheduler.java
+++ b/src/main/java/ku_rum/backend/global/batch/BatchScheduler.java
@@ -24,7 +24,7 @@ public class BatchScheduler {
     private final JobLauncher jobLauncher;
     private final BatchConfig batchConfig;
 
-    @PostConstruct // 애플리케이션 실행 후 한 번 실행
+    //@PostConstruct // 애플리케이션 실행 후 한 번 실행
     public void runJobOnStartup() {
         log.info("🚀 애플리케이션 실행 직후 배치 실행");
         runJob();

--- a/src/main/java/ku_rum/backend/global/config/AuthorizationList.java
+++ b/src/main/java/ku_rum/backend/global/config/AuthorizationList.java
@@ -25,7 +25,8 @@ public final class AuthorizationList {
             "/api/v1/users/reset-account",
             "/actuator/**",
             "/api/v1/users/password-reset/initiate",
-            "/api/v1/images/**"
+            "/api/v1/images/**",
+            "/api/v1/notices/recent/5notices"
     );
 
     private AuthorizationList() {

--- a/src/main/java/ku_rum/backend/global/config/S3Config.java
+++ b/src/main/java/ku_rum/backend/global/config/S3Config.java
@@ -1,3 +1,4 @@
+/*
 package ku_rum.backend.global.config;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
@@ -36,3 +37,4 @@ public class S3Config {
                 .build();
     }
 }
+*/

--- a/src/main/java/ku_rum/backend/global/config/redis/RedissonConfig.java
+++ b/src/main/java/ku_rum/backend/global/config/redis/RedissonConfig.java
@@ -1,0 +1,28 @@
+/*
+package ku_rum.backend.global.config.redis;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient(@Value("${spring.data.redis.host}") String host,
+                                         @Value("${spring.data.redis.port}") String port) {
+
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress(REDISSON_HOST_PREFIX + host + ":" + port)
+                .setDatabase(1);
+
+        return Redisson.create(config);
+    }
+}
+*/

--- a/src/main/java/ku_rum/backend/global/exception/notice/InvalidViewCountException.java
+++ b/src/main/java/ku_rum/backend/global/exception/notice/InvalidViewCountException.java
@@ -1,0 +1,19 @@
+package ku_rum.backend.global.exception.notice;
+
+import ku_rum.backend.global.support.status.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class InvalidViewCountException extends RuntimeException {
+    private final ResponseStatus exceptionStatus;
+
+    public InvalidViewCountException(ResponseStatus exceptionStatus) {
+        super(exceptionStatus.getMessage());
+        this.exceptionStatus = exceptionStatus;
+    }
+
+    public InvalidViewCountException(ResponseStatus exceptionStatus, String message) {
+        super(message);
+        this.exceptionStatus = exceptionStatus;
+    }
+}

--- a/src/main/java/ku_rum/backend/global/exception/notice/RedisSynchronizationException.java
+++ b/src/main/java/ku_rum/backend/global/exception/notice/RedisSynchronizationException.java
@@ -1,0 +1,20 @@
+package ku_rum.backend.global.exception.notice;
+
+import ku_rum.backend.global.support.status.ResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class RedisSynchronizationException extends RuntimeException {
+
+  private final ResponseStatus exceptionStatus;
+
+  public RedisSynchronizationException(ResponseStatus exceptionStatus) {
+    super(exceptionStatus.getMessage());
+    this.exceptionStatus = exceptionStatus;
+  }
+
+  public RedisSynchronizationException(ResponseStatus exceptionStatus, String message) {
+    super(message);
+    this.exceptionStatus = exceptionStatus;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: kurum
   profiles:
-    active: prod
+    active: local
 
   thymeleaf:
     prefix: classpath:/templates/

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: kurum
   profiles:
-    active: local
+    active: prod
 
   thymeleaf:
     prefix: classpath:/templates/

--- a/src/test/java/ku_rum/backend/domain/common/image/presentation/ImageControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/common/image/presentation/ImageControllerTest.java
@@ -1,3 +1,4 @@
+/*
 package ku_rum.backend.domain.common.image.presentation;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
@@ -78,4 +79,4 @@ class ImageControllerTest extends RestDocsTestSupport {
                         )
                 ));
     }
-}
+}*/

--- a/src/test/java/ku_rum/backend/domain/notice/domain/NoticeRecentControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/notice/domain/NoticeRecentControllerTest.java
@@ -3,6 +3,7 @@ package ku_rum.backend.domain.notice.domain;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import ku_rum.backend.config.RestDocsTestSupport;
 import ku_rum.backend.domain.notice.application.NoticeService;
+import ku_rum.backend.domain.notice.dto.response.NoticeSimpleResponse;
 import ku_rum.backend.domain.notice.dto.response.RecentSearchTerm;
 import ku_rum.backend.global.batch.BatchConfig;
 import ku_rum.backend.global.domain.repository.ApiLogRepository;
@@ -98,4 +99,50 @@ class NoticeRecentControllerTest  extends RestDocsTestSupport {
                                             fieldWithPath("data.searchedList").type(JsonFieldType.ARRAY).description("최근 검색어 목록")
                                         ).build())));
     }
+
+    @DisplayName("최근 공지사항 5개 조회 테스트")
+    @Test
+    @WithMockUser(username = "testUser", roles = "USER")
+    void recent5Notices() throws Exception {
+        // Mock 데이터 준비
+        List<NoticeSimpleResponse> mockResponse = List.of(
+                new NoticeSimpleResponse("https://www.konkuk.ac.kr/bbs/konkuk/243/1142471/artclView.do", "2025. 3. 1.자 강사/비전임 2차 공개채용 최종합격자 발표", "2025.01.24", "채용", false),
+                new NoticeSimpleResponse("https://www.konkuk.ac.kr/bbs/konkuk/243/1148491/artclView.do", "건국대학교 교수학습센터 전문직(연구행정직) 채용 공고", "2025.04.11", "채용", false),
+                new NoticeSimpleResponse("https://www.konkuk.ac.kr/bbs/konkuk/243/1148581/artclView.do", "수의과대학 행정지원직 채용 공고", "2025.04.14", "채용", false),
+                new NoticeSimpleResponse("https://www.konkuk.ac.kr/bbs/konkuk/243/1148795/artclView.do", "건국대학교 경영대학 행정실 행정지원직 채용 공고", "2025.04.17", "채용", false),
+                new NoticeSimpleResponse("https://www.konkuk.ac.kr/bbs/konkuk/243/1148862/artclView.do", "건국대학교 법학전문대학원 직원(행정지원직) 채용", "2025.04.18", "채용", false)
+        );
+
+        given(noticeService.getRecent5Notices()).willReturn(mockResponse);
+
+        mockMvc.perform(get("/api/v1/notices/recent/5notices")
+                        .with(user(customUserDetails))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].title").value("2025. 3. 1.자 강사/비전임 2차 공개채용 최종합격자 발표"))
+                .andExpect(jsonPath("$.data[1].title").value("건국대학교 교수학습센터 전문직(연구행정직) 채용 공고"))
+                .andExpect(jsonPath("$.data.length()").value(5))
+                .andDo(restDocs.document(
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("공지사항 API")
+                                        .description("최근 공지사항 5개 가져오기")
+                                        .responseFields(
+                                                fieldWithPath("status").type(JsonFieldType.STRING).description("요청 성공 여부"),
+                                                fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                                fieldWithPath("data[].url").type(JsonFieldType.STRING).description("공지사항 URL"),
+                                                fieldWithPath("data[].title").type(JsonFieldType.STRING).description("공지사항 제목"),
+                                                fieldWithPath("data[].date").type(JsonFieldType.STRING).description("공지사항 날짜"),
+                                                fieldWithPath("data[].category").type(JsonFieldType.STRING).description("공지사항 카테고리"),
+                                                fieldWithPath("data[].important").type(JsonFieldType.BOOLEAN).description("중요 공지 여부")
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+
+
+
 }

--- a/src/test/java/ku_rum/backend/domain/notice/domain/NoticeViewCountControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/notice/domain/NoticeViewCountControllerTest.java
@@ -1,0 +1,134 @@
+/*
+package ku_rum.backend.domain.notice.domain;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import ku_rum.backend.BackendApplication;
+import ku_rum.backend.config.RestDocsTestSupport;
+import ku_rum.backend.domain.notice.application.NoticeService;
+import ku_rum.backend.domain.notice.application.ViewCountService;
+import ku_rum.backend.domain.user.application.UserService;
+import ku_rum.backend.global.batch.BatchConfig;
+import ku_rum.backend.global.log.domain.repository.ApiLogRepository;
+import ku_rum.backend.global.security.CustomUserDetails;
+import ku_rum.backend.global.security.JwtTokenProvider;
+import ku_rum.backend.global.utils.RedisUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = BackendApplication.class)
+@ActiveProfiles("test")
+public class NoticeViewCountControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    private ViewCountService viewCountService;
+
+    @MockBean
+    private NoticeService noticeService;
+
+    @MockBean
+    private BatchConfig batchConfig;
+
+    @MockBean
+    private JobLauncher jobLauncher;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    private RedisUtil redisUtil;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private ApiLogRepository apiLogRepository;
+
+    private CustomUserDetails customUserDetails;
+
+    @DisplayName("공지사항 조회수 증가 테스트")
+    @Test
+    @WithMockUser(username = "testUser", roles = "USER")
+    void increaseViewCount() throws Exception {
+        // Given
+        String url = "https://www.konkuk.ac.kr/bbs/konkuk/234/1147020/artclView.do";
+        String responseMessage = url + "에 대해 조회수가 증가되었습니다.";
+        doNothing().when(viewCountService).enqueueLockRequest(anyString());
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/notices/url")
+                        .param("url", url)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data").value(responseMessage))
+                .andDo(restDocs.document(resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("공지사항 API")
+                                .description("공지사항 조회수 증가")
+                                .queryParameters(
+                                        parameterWithName("url").description("조회수를 증가시킬 공지사항 URL")
+                                )
+                                .responseFields(
+                                        fieldWithPath("code").description("응답 코드 (200)"),
+                                        fieldWithPath("status").description("응답 상태 (OK)"),
+                                        fieldWithPath("message").description("응답 메시지 (OK)"),
+                                        fieldWithPath("data").description("조회수 증가 결과 메시지")
+                                )
+                                .build()
+                )));
+    }
+
+    @Test
+    @DisplayName("조회수가 가장 많은 공지사항 목록 조회 테스트")
+    @WithMockUser(username = "testUser", roles = "USER")
+    void testMostViewedNotices() throws Exception {
+        // Given
+        when(viewCountService.mostViewedNotices()).thenReturn(List.of("2025학년도 1학기 분할납부 2차 납부안내(고지서 출력)"));
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/notices/popular/url")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data[0]").value("2025학년도 1학기 분할납부 2차 납부안내(고지서 출력)"))
+                .andDo(restDocs.document(resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("공지사항 API")
+                                .description("조회수가 가장 많은 공지사항 목록 조회")
+                                .responseFields(
+                                        fieldWithPath("code").description("응답 코드 (200)"),
+                                        fieldWithPath("status").description("응답 상태 (OK)"),
+                                        fieldWithPath("message").description("응답 메시지 (OK)"),
+                                        fieldWithPath("data").description("조회수가 많은 공지사항 목록")
+                                )
+                                .build()
+                )));
+    }
+
+}
+*/


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closes #203 

## 📝작업 내용
- [x] 최신 공지사항 5개를 Native Query에서 `order by notice.createdAt desc` 을 기준으로 상위 5개를 뽑아 구현하였습니다.

## 💬리뷰 요구사항
현재는 '홈' 페이지에 접속할 때마다 
최신 공지사항 5개를 매번 데이터베이스에서 _SELECT ~ ORDER BY createdAt DESC_ _LIMIT 5_ 쿼리로 조회하는 것으로 구현했는데 
공지사항의 업데이트 주기를 고려했을 때 비효율적인 것 같습니다. 

최근 공지사항 목록을 캐싱해, 캐시 DB에 데이터가 있으면 이를 반환하고, 
없으면 데이터베이스에서 조회한 후 캐시에 저장하는 방식으로 개선하는 것이 좋을까요?