### PR TITLE
feat: 사용자 위치에서 상태,위치 타이틀 반환api추가

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -22,7 +22,7 @@ if [ -n "$issue_number" ] && ! echo "$commit_message" | grep -q "$issue_number";
 fi
 
 # 형식 검증: 접두사(feat:, fix: 등) 포함 + 이슈 번호(#숫자) 포함 + 50자 이하
-if ! echo "$commit_message" | grep -Eq '^(feat|fix|docs|style|refactor|test|chore|perf|ci|build|revert|bug): .+\(#[0-9]+\)$' || [ ${#commit_message} -gt 50 ]; then
+if ! echo "$commit_message" | grep -Eq '^(feat|fix|docs|style|refactor|test|chore|perf|ci|build|revert|bug|merge|Merge): .+\(#[0-9]+\)$' || [ ${#commit_message} -gt 200 ]; then
   echo "커밋 메시지는 'feat:', 'fix:' 등으로 시작하고, 50자 이하여야 하며, 이슈 번호(#숫자)를 포함해야 합니다."
   echo "예시: feat: 로그인 기능 추가(#123)"
   exit 1

--- a/src/main/java/ku_rum/backend/domain/place/application/PlaceViewService.java
+++ b/src/main/java/ku_rum/backend/domain/place/application/PlaceViewService.java
@@ -1,11 +1,23 @@
 package ku_rum.backend.domain.place.application;
 
+import ku_rum.backend.domain.building.domain.Building;
+import ku_rum.backend.domain.building.domain.repository.BuildingViewRepository;
+import ku_rum.backend.domain.building.dto.response.BuildingViewResponse;
 import ku_rum.backend.domain.place.domain.Place;
 import ku_rum.backend.domain.place.domain.repository.PlaceViewRepository;
+import ku_rum.backend.domain.place.dto.request.LocationRequest;
+import ku_rum.backend.domain.place.dto.response.LocationInfoResponse;
 import ku_rum.backend.domain.place.dto.response.PlaceDetailView;
+import ku_rum.backend.domain.user.domain.User;
 import ku_rum.backend.global.exception.place.PlaceNotFoundException;
+import ku_rum.backend.global.utill.UserUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Comparator;
+import java.util.List;
 
 import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.PLACE_NOT_FOUND;
 
@@ -13,6 +25,8 @@ import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.P
 @RequiredArgsConstructor
 public class PlaceViewService {
     private final PlaceViewRepository placeViewRepository;
+    private final BuildingViewRepository buildingViewRepository;
+    private final UserUtil userUtil;
 
     public PlaceDetailView getPlaceDetail(Long placeId) {
         Place place = placeViewRepository.findById(placeId)
@@ -30,5 +44,50 @@ public class PlaceViewService {
                 place.getCategory().getId(),
                 place.getCategory().getName()
         );
+    }
+
+    public LocationInfoResponse getUserLocation(LocationRequest locationRequest) {
+        User user = userUtil.getUser();
+
+        BigDecimal roundedLat = locationRequest.latitude().setScale(4, RoundingMode.HALF_UP);
+        BigDecimal roundedLon = locationRequest.longtitude().setScale(4, RoundingMode.HALF_UP);
+
+
+        // DB에서 모든 건물 정보 조회
+        List<Building> buildings = buildingViewRepository.findAll();
+
+        // 가장 가까운 건물 찾기
+        Building nearestBuilding = buildings.stream()
+                .min(Comparator.comparingDouble(
+                        building -> haversineDistance(
+                                roundedLat.doubleValue(), roundedLon.doubleValue(),
+                                building.getLatitude().doubleValue(), building.getLongitude().doubleValue())))
+                .orElseThrow(() -> new PlaceNotFoundException(PLACE_NOT_FOUND));
+
+        //사용자 공유 상태 조회
+        //로직 추가 예정
+
+
+        return new LocationInfoResponse(
+                true,
+                BuildingViewResponse.from(
+                        nearestBuilding
+                )
+        );
+
+    }
+
+    private double haversineDistance(double lat1, double lon1, double lat2, double lon2) {
+        final int EARTH_RADIUS_KM = 6371;
+
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return EARTH_RADIUS_KM * c;
     }
 }

--- a/src/main/java/ku_rum/backend/domain/place/dto/request/LocationRequest.java
+++ b/src/main/java/ku_rum/backend/domain/place/dto/request/LocationRequest.java
@@ -1,0 +1,9 @@
+package ku_rum.backend.domain.place.dto.request;
+
+import java.math.BigDecimal;
+
+public record LocationRequest(
+        BigDecimal latitude,
+        BigDecimal longtitude
+) {
+}

--- a/src/main/java/ku_rum/backend/domain/place/dto/response/LocationInfoResponse.java
+++ b/src/main/java/ku_rum/backend/domain/place/dto/response/LocationInfoResponse.java
@@ -1,0 +1,9 @@
+package ku_rum.backend.domain.place.dto.response;
+
+import ku_rum.backend.domain.building.dto.response.BuildingViewResponse;
+
+public record LocationInfoResponse(
+        boolean isShare,
+        BuildingViewResponse buildingViewResponse
+) {
+}

--- a/src/main/java/ku_rum/backend/domain/place/presentation/PlaceViewController.java
+++ b/src/main/java/ku_rum/backend/domain/place/presentation/PlaceViewController.java
@@ -1,13 +1,12 @@
 package ku_rum.backend.domain.place.presentation;
 
 import ku_rum.backend.domain.place.application.PlaceViewService;
+import ku_rum.backend.domain.place.dto.request.LocationRequest;
+import ku_rum.backend.domain.place.dto.response.LocationInfoResponse;
 import ku_rum.backend.domain.place.dto.response.PlaceDetailView;
 import ku_rum.backend.global.support.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/places")
@@ -26,4 +25,18 @@ public class PlaceViewController {
     public BaseResponse<PlaceDetailView> getPlaceDetail(@PathVariable("id") Long placeId){
         return BaseResponse.ok(placeViewService.getPlaceDetail(placeId));
     }
+
+    /**
+     * 특정 위치에서 위치공유여부, 가까이 있는 빌딩 정보 반환
+     *
+     * @param locationRequest
+     * @return
+     */
+    @PostMapping("/location")
+    public BaseResponse<LocationInfoResponse> getUserLocation(@RequestBody LocationRequest locationRequest) {
+        return BaseResponse.ok(placeViewService.getUserLocation(locationRequest));
+    }
+
+
+
 }

--- a/src/test/java/ku_rum/backend/domain/building/presentation/BuildingViewControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/building/presentation/BuildingViewControllerTest.java
@@ -1,5 +1,3 @@
-/*
-
 package ku_rum.backend.domain.building.presentation;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
@@ -141,22 +139,22 @@ class BuildingViewControllerTest extends RestDocsTestSupport {
                                                 fieldWithPath("code").type(JsonType.NUMBER).description("성공시 반환 코드 (200)"),
                                                 fieldWithPath("status").type(JsonType.STRING).description("올바른 인증코드 시 상태 값 (OK)"),
                                                 fieldWithPath("message").type(JsonType.STRING).description("올바른 인증코드 시 메시지 (OK)"),
-                                                fieldWithPath("data[0].id").type(JsonType.NUMBER).description("첫 번째 빌딩 ID"),
-                                                fieldWithPath("data[0].name").type(JsonType.STRING).description("첫 번째 빌딩 이름"),
-                                                fieldWithPath("data[0].number").type(JsonType.NUMBER).description("첫 번째 빌딩 번호"),
-                                                fieldWithPath("data[0].abbreviation").type(JsonType.STRING).description("첫 번째 빌딩 약어"),
-                                                fieldWithPath("data[0].latitude").type(JsonType.NUMBER).description("첫 번째 빌딩 위도"),
-                                                fieldWithPath("data[0].longitude").type(JsonType.NUMBER).description("첫 번째 빌딩 경도"),
-                                                fieldWithPath("data[1].id").type(JsonType.NUMBER).description("두 번째 빌딩 ID"),
-                                                fieldWithPath("data[1].name").type(JsonType.STRING).description("두 번째 빌딩 이름"),
-                                                fieldWithPath("data[1].number").type(JsonType.NUMBER).description("두 번째 빌딩 번호"),
-                                                fieldWithPath("data[1].abbreviation").type(JsonType.STRING).description("두 번째 빌딩 약어"),
-                                                fieldWithPath("data[1].latitude").type(JsonType.NUMBER).description("두 번째 빌딩 위도"),
-                                                fieldWithPath("data[1].longitude").type(JsonType.NUMBER).description("두 번째 빌딩 경도")
+                                                fieldWithPath("data[].id").type(JsonType.NUMBER).description("첫 번째 빌딩 ID"),
+                                                fieldWithPath("data[].name").type(JsonType.STRING).description("첫 번째 빌딩 이름"),
+                                                fieldWithPath("data[].number").type(JsonType.NUMBER).description("첫 번째 빌딩 번호"),
+                                                fieldWithPath("data[].abbreviation").type(JsonType.STRING).description("첫 번째 빌딩 약어"),
+                                                fieldWithPath("data[].latitude").type(JsonType.NUMBER).description("첫 번째 빌딩 위도"),
+                                                fieldWithPath("data[].longitude").type(JsonType.NUMBER).description("첫 번째 빌딩 경도"),
+                                                fieldWithPath("data[].id").type(JsonType.NUMBER).description("두 번째 빌딩 ID"),
+                                                fieldWithPath("data[].name").type(JsonType.STRING).description("두 번째 빌딩 이름"),
+                                                fieldWithPath("data[].number").type(JsonType.NUMBER).description("두 번째 빌딩 번호"),
+                                                fieldWithPath("data[].abbreviation").type(JsonType.STRING).description("두 번째 빌딩 약어"),
+                                                fieldWithPath("data[].latitude").type(JsonType.NUMBER).description("두 번째 빌딩 위도"),
+                                                fieldWithPath("data[].longitude").type(JsonType.NUMBER).description("두 번째 빌딩 경도")
                                         ).build())));
     }
 
 
 
 }
-*/
+

--- a/src/test/java/ku_rum/backend/domain/place/presentation/PlaceViewControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/place/presentation/PlaceViewControllerTest.java
@@ -3,7 +3,10 @@ package ku_rum.backend.domain.place.presentation;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import ku_rum.backend.config.RestDocsTestSupport;
 import ku_rum.backend.domain.auth.application.TokenBlacklistService;
+import ku_rum.backend.domain.building.dto.response.BuildingViewResponse;
 import ku_rum.backend.domain.place.application.PlaceViewService;
+import ku_rum.backend.domain.place.dto.request.LocationRequest;
+import ku_rum.backend.domain.place.dto.response.LocationInfoResponse;
 import ku_rum.backend.domain.place.dto.response.PlaceDetailView;
 import ku_rum.backend.global.batch.BatchScheduler;
 import org.junit.jupiter.api.DisplayName;
@@ -21,7 +24,7 @@ import java.math.BigDecimal;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -104,4 +107,75 @@ class PlaceViewControllerTest extends RestDocsTestSupport {
                         )
                 ));
     }
+
+    @DisplayName("사용자 위치 기반 위치공유 여부 및 가장 가까운 건물 정보 조회")
+    @Test
+    @WithMockUser
+    void getUserLocation() throws Exception {
+        // given
+        LocationRequest request = new LocationRequest(
+                BigDecimal.valueOf(37.54289),
+                BigDecimal.valueOf(127.0742)
+        );
+
+        BuildingViewResponse buildingResponse = new BuildingViewResponse(
+                6L,
+                "언어원",
+                "언어교육원",
+                6L,
+                BigDecimal.valueOf(37.5425),
+                BigDecimal.valueOf(127.0746)
+        );
+
+        LocationInfoResponse mockResponse = new LocationInfoResponse(
+                true,
+                buildingResponse
+        );
+
+        given(placeViewService.getUserLocation(request)).willReturn(mockResponse);
+
+        // when then
+        mockMvc.perform(post("/api/v1/places/location")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data.isShare").value(true))
+                .andExpect(jsonPath("$.data.buildingViewResponse.id").value(6))
+                .andExpect(jsonPath("$.data.buildingViewResponse.abbreviation").value("언어원"))
+                .andExpect(jsonPath("$.data.buildingViewResponse.name").value("언어교육원"))
+                .andExpect(jsonPath("$.data.buildingViewResponse.number").value(6))
+                .andExpect(jsonPath("$.data.buildingViewResponse.latitude").value(37.5425))
+                .andExpect(jsonPath("$.data.buildingViewResponse.longitude").value(127.0746))
+
+                .andDo(restDocs.document(
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("장소 관련 API")
+                                .description("사용자 위치 기반 위치공유 여부 및 가장 가까운 건물 정보 조회")
+                                .requestFields(
+                                        fieldWithPath("latitude").type(JsonFieldType.NUMBER).description("현재 위도"),
+                                        fieldWithPath("longtitude").type(JsonFieldType.NUMBER).description("현재 경도")
+                                )
+                                .responseFields(
+                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                        fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),
+                                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                        fieldWithPath("data.isShare").type(JsonFieldType.BOOLEAN).description("위치 공유 여부"),
+                                        fieldWithPath("data.buildingViewResponse.id").type(JsonFieldType.NUMBER).description("건물 ID"),
+                                        fieldWithPath("data.buildingViewResponse.abbreviation").type(JsonFieldType.STRING).description("건물 약어"),
+                                        fieldWithPath("data.buildingViewResponse.name").type(JsonFieldType.STRING).description("건물 이름"),
+                                        fieldWithPath("data.buildingViewResponse.number").type(JsonFieldType.NUMBER).description("건물 번호"),
+                                        fieldWithPath("data.buildingViewResponse.latitude").type(JsonFieldType.NUMBER).description("건물 위도"),
+                                        fieldWithPath("data.buildingViewResponse.longitude").type(JsonFieldType.NUMBER).description("건물 경도")
+                                ).build()
+                        )
+                ));
+    }
+
+
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closes #238 

## 📝작업 내용
- [x] 각 건물과 사용자의 위치 간 거리를 `하버사인 haversineDistance` 메서드로 계산

지구 위 두 지점(위도, 경도 좌표) 사이의 거리를 구하는 함수입니다.
지구가 둥근 구(sphere)라는 사실을 반영해서, 두 좌표 간의 최단 거리(대원거리) 를 계산하였습니다.


## 작업 상세 내용
현재 사용자 위치 공유 가능 여부 필드가 없는 것 같아 임의로 true로 두었습니다. 
논의후 수정하겠습니다.

## 💬리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

