### PR TITLE
refactor: 지도 9, 10 api 추가 (#261)

### DIFF
--- a/src/main/java/ku_rum/backend/domain/place/application/PlaceFriendInfoService.java
+++ b/src/main/java/ku_rum/backend/domain/place/application/PlaceFriendInfoService.java
@@ -12,10 +12,12 @@ import ku_rum.backend.domain.place.dto.response.PlaceFriendInfo2Response;
 import ku_rum.backend.domain.place.dto.response.PlaceFriendInfoResponse;
 import ku_rum.backend.domain.place.dto.response.PlaceSearchInfoResponse;
 import ku_rum.backend.domain.user.domain.User;
+import ku_rum.backend.global.utill.RedisUtil;
 import ku_rum.backend.global.utill.UserUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,6 +38,8 @@ public class PlaceFriendInfoService {
 
     private final AmazonS3 amazonS3;
     private final UserUtil userUtil;
+    private final RedisUtil redisUtil;
+
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -106,6 +110,10 @@ public class PlaceFriendInfoService {
 
     @Transactional
     public List<PlaceSearchInfoResponse> getPlacesNameBySearch(String search) {
+        //최근 검색어 redis에 저장
+        Long currentUserId = userUtil.getUser().getId();
+        redisUtil.setRedisData("user:" + currentUserId + ":recent-search", search);
+
         List<PlaceSearchInfoResponse> resultList = new ArrayList<>();
 
         //place.name, place.subName 에서 검색
@@ -199,4 +207,24 @@ public class PlaceFriendInfoService {
                 .toList();
     }
 
+    @Transactional
+    public List<String> getSearchTermList() {
+        Long currentUserId = userUtil.getUser().getId();
+
+        String key = "user:" + currentUserId + ":recent-search";
+
+        List<String> recentSearches = redisUtil.getRecentSearchList(key, 10);
+
+        return recentSearches != null ? recentSearches : List.of();
+    }
+
+    @Transactional
+    public String deleteSearchTerm(String term) {
+        Long currentUserId = userUtil.getUser().getId();
+        String key = "user:" + currentUserId + ":recent-search";
+
+        redisUtil.removeRecentSearch(key, term);
+
+        return "최근 검색어 삭제 완료";
+    }
 }

--- a/src/main/java/ku_rum/backend/domain/place/dto/request/DeleteSearchTermRequest.java
+++ b/src/main/java/ku_rum/backend/domain/place/dto/request/DeleteSearchTermRequest.java
@@ -1,0 +1,6 @@
+package ku_rum.backend.domain.place.dto.request;
+
+public record DeleteSearchTermRequest(
+        String term
+) {
+}

--- a/src/main/java/ku_rum/backend/domain/place/presentation/PlaceFriendInfoController.java
+++ b/src/main/java/ku_rum/backend/domain/place/presentation/PlaceFriendInfoController.java
@@ -1,6 +1,7 @@
 package ku_rum.backend.domain.place.presentation;
 
 import ku_rum.backend.domain.place.application.PlaceFriendInfoService;
+import ku_rum.backend.domain.place.dto.request.DeleteSearchTermRequest;
 import ku_rum.backend.domain.place.dto.request.PlaceSearchRequest;
 import ku_rum.backend.domain.place.dto.response.PlaceFriendInfo2Response;
 import ku_rum.backend.domain.place.dto.response.PlaceFriendInfoResponse;
@@ -69,6 +70,29 @@ public class PlaceFriendInfoController {
     ) {
         List<PlaceFriendInfoResponse> response = placeFriendInfoService.getDetailWithPlacesNameBySearch(request.search());
         return BaseResponse.ok(response);
+    }
+
+    /**
+     * 9. 건물명, 강의실명, 건물번호 검색어 반환
+     *
+     * @return
+     */
+    @GetMapping("/search/term")
+    public BaseResponse<List<String>> getSearchTermList() {
+        List<String> response = placeFriendInfoService.getSearchTermList();
+        return BaseResponse.ok(response);
+    }
+
+    /**
+     * 10. 건물명, 강의실명, 건물번호 검색어 삭제
+     *
+     * @param request
+     * @return
+     */
+    @DeleteMapping("/search/term")
+    public BaseResponse<String> deleteSearchTerm(@RequestBody DeleteSearchTermRequest request) {
+        String result = placeFriendInfoService.deleteSearchTerm(request.term());
+        return BaseResponse.ok(result);
     }
 
 

--- a/src/main/java/ku_rum/backend/global/config/AuthorizationList.java
+++ b/src/main/java/ku_rum/backend/global/config/AuthorizationList.java
@@ -29,7 +29,8 @@ public final class AuthorizationList {
             "/api/v1/auth/token",
             "/api/v1/buildings/**",
             "/api/v1/departments/**",
-            "/api/v1/colleges/**"
+            "/api/v1/colleges/**",
+            "/chip/**"
     );
 
     private AuthorizationList() {

--- a/src/main/java/ku_rum/backend/global/utill/RedisUtil.java
+++ b/src/main/java/ku_rum/backend/global/utill/RedisUtil.java
@@ -6,6 +6,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -46,5 +47,15 @@ public class RedisUtil {
             return "false";
         }
         return redisTemplate.opsForValue().get(key);
+    }
+
+    public List<String> getRecentSearchList(String key, int count) {
+        log.info("레디스에 모든 값 가져오기");
+        return redisTemplate.opsForList().range(key, 0, count - 1);
+    }
+
+    public void removeRecentSearch(String key, String term) {
+        log.info("레디스에 +" + term +"값 가져오기");
+        redisTemplate.opsForList().remove(key, 0, term);
     }
 }

--- a/src/test/java/ku_rum/backend/domain/place/presentation/PlaceFriendInfoControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/place/presentation/PlaceFriendInfoControllerTest.java
@@ -6,6 +6,7 @@ import ku_rum.backend.domain.friend.application.FriendReportService;
 import ku_rum.backend.domain.friend.domain.repository.FriendBlockRepository;
 import ku_rum.backend.domain.notice.domain.repository.NoticeRepositoryImpl;
 import ku_rum.backend.domain.place.application.PlaceFriendInfoService;
+import ku_rum.backend.domain.place.dto.request.DeleteSearchTermRequest;
 import ku_rum.backend.domain.place.dto.request.PlaceSearchRequest;
 import ku_rum.backend.domain.place.dto.response.PlaceFriendInfo2Response;
 import ku_rum.backend.domain.place.dto.response.PlaceFriendInfoResponse;
@@ -33,7 +34,7 @@ import java.util.List;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -78,7 +79,7 @@ public class PlaceFriendInfoControllerTest extends RestDocsTestSupport {
 
     @DisplayName("칩 이름으로 장소 정보와 해당 장소에 위치 공유 중인 친구 정보를 반환한다.")
     @Test
-    @WithMockUser
+    //@WithMockUser
     void getChipDetailInfo() throws Exception {
         // given
         String chipName = "레스티오";
@@ -100,7 +101,6 @@ public class PlaceFriendInfoControllerTest extends RestDocsTestSupport {
 
         // when then
         mockMvc.perform(post("/api/v1/map/chip/{chipName}", chipName)
-                        .header("Authorization", "Bearer ACCESS_TOKEN")
                 )
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -113,9 +113,6 @@ public class PlaceFriendInfoControllerTest extends RestDocsTestSupport {
                         ResourceSnippetParameters.builder()
                                 .tag("NEW 지도 API")
                                 .description("5. 칩 이름으로 장소 정보 및 위치 공유 중인 친구 목록 조회")
-                                .requestHeaders(
-                                        headerWithName("Authorization").description("액세스 토큰 (Bearer Token)")
-                                )
                                 .pathParameters(
                                         parameterWithName("chipName").description("칩 이름 (예: 레스티오)")
                                 )
@@ -305,6 +302,85 @@ public class PlaceFriendInfoControllerTest extends RestDocsTestSupport {
                                         fieldWithPath("data[].longitude").type(JsonFieldType.NUMBER).description("경도"),
                                         fieldWithPath("data[].friendList[].nickname").type(JsonFieldType.STRING).description("위치 공유 중인 친구 닉네임"),
                                         fieldWithPath("data[].friendList[].profileUrl").type(JsonFieldType.STRING).description("친구 프로필 이미지 URL")
+                                )
+                                .build()
+                )));
+    }
+
+
+    @DisplayName("건물명, 강의실명, 건물번호 검색어 리스트 조회")
+    @Test
+    @WithMockUser
+    void getSearchTermList() throws Exception {
+        // given
+        List<String> searchTerms = List.of("신공학관", "종강102", "레스티오");
+        given(placeFriendInfoService.getSearchTermList()).willReturn(searchTerms);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/map/search/term")
+                        .header("Authorization", "Bearer ACCESS_TOKEN"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data[0]").value("신공학관"))
+                .andExpect(jsonPath("$.data[1]").value("종강102"))
+                .andExpect(jsonPath("$.data[2]").value("레스티오"))
+                .andDo(restDocs.document(resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("NEW 지도 API")
+                                .description("9. 건물명, 강의실명, 건물번호 검색어 리스트 반환")
+                                .requestHeaders(
+                                        headerWithName("Authorization").description("액세스 토큰 (Bearer Token)")
+                                )
+                                .responseFields(
+                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                        fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),
+                                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                        fieldWithPath("data[]").type(JsonFieldType.ARRAY).description("최근 검색어 리스트")
+                                )
+                                .build()
+                )));
+    }
+
+
+    @DisplayName("건물명, 강의실명, 건물번호 검색어 삭제")
+    @Test
+    @WithMockUser
+    void deleteSearchTerm() throws Exception {
+        // given
+        String term = "신공학관";
+        DeleteSearchTermRequest request = new DeleteSearchTermRequest(term);
+
+        given(placeFriendInfoService.deleteSearchTerm(term)).willReturn("최근 검색어 삭제 완료");
+
+        // when & then
+        mockMvc.perform(delete("/api/v1/map/search/term")
+                        .header("Authorization", "Bearer ACCESS_TOKEN")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data").value("최근 검색어 삭제 완료"))
+                .andDo(restDocs.document(resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("NEW 지도 API")
+                                .description("10. 건물명, 강의실명, 건물번호 검색어 삭제")
+                                .requestHeaders(
+                                        headerWithName("Authorization").description("액세스 토큰 (Bearer Token)")
+                                )
+                                .requestFields(
+                                        fieldWithPath("term").type(JsonFieldType.STRING).description("삭제할 검색어")
+                                )
+                                .responseFields(
+                                        fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+                                        fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태"),
+                                        fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
+                                        fieldWithPath("data").type(JsonFieldType.STRING).description("삭제 결과 메시지")
                                 )
                                 .build()
                 )));


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closes #261 

## 📝작업 내용
- 5번 로그인 없이 가능하게
- 8번에 대해 최근 검색어 mainTitle형식으로 api 추가 ->9번 api
- 8번에 대해 최근 검색어 삭제 -> 10번 api

## 작업 상세 내용
상세 내용을 입력해주세요.

## 💬리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

