### PR TITLE
[FEAT] 위치 공유 초기화 로직

### DIFF
--- a/src/main/java/ku_rum/backend/domain/place/application/PositionScheduler.java
+++ b/src/main/java/ku_rum/backend/domain/place/application/PositionScheduler.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
@@ -23,6 +24,7 @@ public class PositionScheduler {
     private final PlaceRankRepository placeRankRepository;
 
     @Scheduled(cron = "0 0 0 * * ?")
+    @Transactional
     public void resetPosition() {
         List<Long> positions = positionRepository.findAll().stream()
                 .filter(this::isUpperBound)

--- a/src/main/java/ku_rum/backend/domain/place/application/PositionScheduler.java
+++ b/src/main/java/ku_rum/backend/domain/place/application/PositionScheduler.java
@@ -22,8 +22,7 @@ public class PositionScheduler {
     private final PositionRepository positionRepository;
     private final PlaceRankRepository placeRankRepository;
 
-    /// @Scheduled(cron = "0 0 0 * * ?")
-    @Scheduled(fixedRate = 5000)
+    @Scheduled(cron = "0 0 0 * * ?")
     public void resetPosition() {
         List<Long> positions = positionRepository.findAll().stream()
                 .filter(this::isUpperBound)

--- a/src/main/java/ku_rum/backend/domain/place/application/PositionScheduler.java
+++ b/src/main/java/ku_rum/backend/domain/place/application/PositionScheduler.java
@@ -1,0 +1,41 @@
+package ku_rum.backend.domain.place.application;
+
+import static java.time.Duration.between;
+import static ku_rum.backend.domain.place.application.PositionService.CRITERION_TIME;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import ku_rum.backend.domain.place.domain.Position;
+import ku_rum.backend.domain.place.domain.repository.PositionRepository;
+import ku_rum.backend.domain.rank.domain.repository.PlaceRankRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PositionScheduler {
+
+    private final PositionRepository positionRepository;
+    private final PlaceRankRepository placeRankRepository;
+
+    /// @Scheduled(cron = "0 0 0 * * ?")
+    @Scheduled(fixedRate = 5000)
+    public void resetPosition() {
+        List<Long> positions = positionRepository.findAll().stream()
+                .filter(this::isUpperBound)
+                .map(Position::getPositionId)
+                .toList();
+        placeRankRepository.updatePlaceRankByPositions(positions);
+
+        positionRepository.deleteAll();
+    }
+
+    boolean isUpperBound(Position position) {
+        Duration minusTime = between(LocalDateTime.now(), position.getCreatedAt());
+        return minusTime.getSeconds() >= CRITERION_TIME;
+    }
+}

--- a/src/main/java/ku_rum/backend/domain/place/application/PositionService.java
+++ b/src/main/java/ku_rum/backend/domain/place/application/PositionService.java
@@ -35,7 +35,7 @@ public class PositionService {
     private final UserService userService;
     private final RankService rankService;
 
-    private static final long CRITERION_TIME = 3600L;
+    public static final long CRITERION_TIME = 3600L;
 
     /**
      * 사용자 위치 공유 여부 확인

--- a/src/main/java/ku_rum/backend/domain/place/application/PositionService.java
+++ b/src/main/java/ku_rum/backend/domain/place/application/PositionService.java
@@ -103,7 +103,7 @@ public class PositionService {
                 .orElseThrow(() -> new GlobalException(NO_SUCH_DEPARTMENT));
         positionRepository.deleteByUser(user);
 
-        Duration minusTime = between(LocalDateTime.now(), position.getCreatedAt());
+        Duration minusTime = between(position.getCreatedAt(), LocalDateTime.now());
         boolean isUpperBound = minusTime.getSeconds() >= CRITERION_TIME;
 
         try {

--- a/src/main/java/ku_rum/backend/domain/place/application/PositionService.java
+++ b/src/main/java/ku_rum/backend/domain/place/application/PositionService.java
@@ -1,5 +1,11 @@
 package ku_rum.backend.domain.place.application;
 
+import static java.time.Duration.between;
+import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.NO_SUCH_DEPARTMENT;
+import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.PLACE_NOT_FOUND;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import ku_rum.backend.domain.place.application.response.CurrentPositionConfirmResponse;
 import ku_rum.backend.domain.place.application.response.CurrentPositionResponse;
@@ -11,17 +17,16 @@ import ku_rum.backend.domain.place.domain.repository.PositionRepository;
 import ku_rum.backend.domain.place.dto.request.CurrentPositionConfirmRequest;
 import ku_rum.backend.domain.place.dto.request.CurrentPositionRequest;
 import ku_rum.backend.domain.rank.application.RankService;
+import ku_rum.backend.domain.rank.domain.PlaceRank;
 import ku_rum.backend.domain.user.application.UserService;
 import ku_rum.backend.domain.user.domain.User;
 import ku_rum.backend.global.exception.global.GlobalException;
 import ku_rum.backend.global.security.CustomUserDetails;
-import ku_rum.backend.global.support.status.BaseExceptionResponseStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class PositionService {
 
@@ -29,6 +34,8 @@ public class PositionService {
     private final PlaceRepository placeRepository;
     private final UserService userService;
     private final RankService rankService;
+
+    private static final long CRITERION_TIME = 3600L;
 
     /**
      * 사용자 위치 공유 여부 확인
@@ -75,7 +82,6 @@ public class PositionService {
         Optional<Position> positionOptional = positionRepository.findPositionByUser(user);
         Place place = findOneByName(request.placeName());
 
-        rankService.updateRank(user, place);
         if (positionOptional.isPresent()) {
             return updatePosition(positionOptional.get(), place);
         }
@@ -93,7 +99,21 @@ public class PositionService {
      */
     public void disableSharingPosition(CustomUserDetails userDetails) {
         User user = userService.getUser();
+        Position position = positionRepository.findPositionByUser(user)
+                .orElseThrow(() -> new GlobalException(NO_SUCH_DEPARTMENT));
         positionRepository.deleteByUser(user);
+
+        Duration minusTime = between(LocalDateTime.now(), position.getCreatedAt());
+        boolean isUpperBound = minusTime.getSeconds() >= CRITERION_TIME;
+
+        try {
+            PlaceRank userPlaceRank = rankService.getUserPlaceRank(user, position.getPlace());
+            if (isUpperBound) {
+                userPlaceRank.increaseCount();
+            }
+        } catch (Exception ignored) {
+
+        }
     }
 
     /**
@@ -104,7 +124,7 @@ public class PositionService {
      */
     private Place findOneByName(String name) {
         return placeRepository.findOneByName(name)
-                .orElseThrow(() -> new GlobalException(BaseExceptionResponseStatus.PLACE_NOT_FOUND));
+                .orElseThrow(() -> new GlobalException(PLACE_NOT_FOUND));
     }
 
     /**

--- a/src/main/java/ku_rum/backend/domain/place/domain/repository/PositionRepository.java
+++ b/src/main/java/ku_rum/backend/domain/place/domain/repository/PositionRepository.java
@@ -9,6 +9,7 @@ import ku_rum.backend.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface PositionRepository extends JpaRepository<Position, Long> {
 
@@ -16,6 +17,7 @@ public interface PositionRepository extends JpaRepository<Position, Long> {
 
     Optional<Position> findPositionByUser(User user);
 
+    @Transactional
     void deleteByUser(User user);
 
     @Query("""

--- a/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
+++ b/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
@@ -8,7 +8,9 @@ import ku_rum.backend.domain.rank.domain.PlaceRank;
 import ku_rum.backend.domain.rank.domain.repository.PlaceRankRepository;
 import ku_rum.backend.domain.user.application.UserService;
 import ku_rum.backend.domain.user.domain.User;
+import ku_rum.backend.global.exception.global.GlobalException;
 import ku_rum.backend.global.security.CustomUserDetails;
+import ku_rum.backend.global.support.status.BaseExceptionResponseStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,5 +56,10 @@ public class RankService {
                 .place(place)
                 .build();
         placeRankRepository.save(rank);
+    }
+
+    public PlaceRank getUserPlaceRank(User user, Place place) {
+        return placeRankRepository.findByUserAndPlace(user, place).orElseThrow(() -> new GlobalException(
+                BaseExceptionResponseStatus.PLACE_RANK_NOT_FOUND));
     }
 }

--- a/src/main/java/ku_rum/backend/domain/rank/domain/repository/PlaceRankRepository.java
+++ b/src/main/java/ku_rum/backend/domain/rank/domain/repository/PlaceRankRepository.java
@@ -6,7 +6,11 @@ import ku_rum.backend.domain.place.domain.Place;
 import ku_rum.backend.domain.rank.domain.PlaceRank;
 import ku_rum.backend.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 public interface PlaceRankRepository extends JpaRepository<PlaceRank, Long> {
@@ -14,4 +18,15 @@ public interface PlaceRankRepository extends JpaRepository<PlaceRank, Long> {
     List<PlaceRank> findTop3ByUserOrderByCountDesc(User user);
 
     Optional<PlaceRank> findByUserAndPlace(User user, Place place);
+
+    @Modifying
+    @Transactional
+    @Query(value = """
+                UPDATE place_rank pr
+                JOIN place pl ON pr.place_place_id = pl.place_id
+                JOIN position po ON po.place_place_id = pl.place_id
+                SET pr.count = pr.count + 1
+                WHERE po.position_id IN (:positionIds)
+            """, nativeQuery = true)
+    void updatePlaceRankByPositions(@Param("positionIds") List<Long> positionIds);
 }

--- a/src/main/java/ku_rum/backend/global/config/SchedulerConfig.java
+++ b/src/main/java/ku_rum/backend/global/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package ku_rum.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class SchedulerConfig {
+}

--- a/src/main/java/ku_rum/backend/global/support/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/ku_rum/backend/global/support/status/BaseExceptionResponseStatus.java
@@ -120,7 +120,8 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
      */
     PLACE_NOT_FOUND(1200, HttpStatus.NOT_FOUND, "해당되는 장소가 없습니다."),
     PLACE_IMAGE_NOT_FOUND(1201, HttpStatus.NOT_FOUND, "해당되는 장소 이미지가 없습니다."),
-    UNSUPPORTED_FRIEND_CHIP_ERROR(1202, HttpStatus.UNAUTHORIZED, "비회원으로 친구를 조회할 수 없습니다");
+    UNSUPPORTED_FRIEND_CHIP_ERROR(1202, HttpStatus.UNAUTHORIZED, "비회원으로 친구를 조회할 수 없습니다"),
+    PLACE_RANK_NOT_FOUND(1203, HttpStatus.NOT_FOUND, "해당되는 랭크장소가 없습니다.");
 
     private final int code;
     private final HttpStatus status;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closes #299 

## 📝작업 내용
- [x] 위치 공유 초기화 로직

## 작업 상세 내용
상세 내용을 입력해주세요.

## 💬리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 매일 0시에 위치 기록을 정리하고 관련 장소 랭크를 일괄 반영합니다.
  - 위치 공유를 1시간(3600초) 이상 유지한 뒤 해제하면 해당 장소의 랭크가 자동으로 1 증가합니다.
- 개선
  - 스케줄링이 활성화되어 정기 작업이 안정적으로 수행됩니다.
- 기타
  - 장소 랭크 관련 오류 상태가 추가되어 관련 에러 메시지가 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->