### PR TITLE
소셜 로그인 변경

### DIFF
--- a/src/main/java/ku_rum/backend/domain/auth/application/AuthService.java
+++ b/src/main/java/ku_rum/backend/domain/auth/application/AuthService.java
@@ -146,7 +146,6 @@ public class AuthService {
                 user.getNickname(),
                 user.getStudentId(),
                 user.getImageUrl(),
-                list,
-                user.isFirstLogin());
+                list);
     }
 }

--- a/src/main/java/ku_rum/backend/domain/oauth/application/CustomOAuth2UserService.java
+++ b/src/main/java/ku_rum/backend/domain/oauth/application/CustomOAuth2UserService.java
@@ -48,6 +48,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                                 " account. Please use your " + member.getProviderType() + " account to login."
                 );
             }
+            if (member.isFirstLogin()) {
+                member.changeFirstLogin(false);
+                userRepository.save(member);
+            }
         } else {
             member = createUser(memberInfo, providerType);
         }

--- a/src/main/java/ku_rum/backend/domain/user/domain/User.java
+++ b/src/main/java/ku_rum/backend/domain/user/domain/User.java
@@ -122,7 +122,6 @@ public class User extends BaseEntity {
         return User.builder()
                 .oauthId(memberInfo.getId())
                 .nickname(memberInfo.getName())
-                .email(memberInfo.getEmail())
                 .providerType(providerType) // enum 변환
                 .build();
     }

--- a/src/main/java/ku_rum/backend/domain/user/dto/response/TokenResponse.java
+++ b/src/main/java/ku_rum/backend/domain/user/dto/response/TokenResponse.java
@@ -3,9 +3,9 @@ package ku_rum.backend.domain.user.dto.response;
 import jakarta.validation.constraints.NotBlank;
 
 public record TokenResponse(@NotBlank String accessToken, @NotBlank String refreshToken, @NotBlank long accessExpireIn,
-                            @NotBlank long refreshExpireIn) {
+                            @NotBlank long refreshExpireIn, boolean isFirstLogin) {
 
-    public static TokenResponse of(String accessToken, String refreshToken, long accessExpireIn, long refreshExpireIn) {
-        return new TokenResponse(accessToken, refreshToken, accessExpireIn, refreshExpireIn);
+    public static TokenResponse of(String accessToken, String refreshToken, long accessExpireIn, long refreshExpireIn, boolean isFirstLogin) {
+        return new TokenResponse(accessToken, refreshToken, accessExpireIn, refreshExpireIn, isFirstLogin);
     }
 }

--- a/src/main/java/ku_rum/backend/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/ku_rum/backend/domain/user/dto/response/UserResponse.java
@@ -5,9 +5,9 @@ import ku_rum.backend.domain.department.dto.DepartmentResponse;
 import java.util.List;
 
 public record UserResponse(Long id, String oauthId, String loginId, String email, String nickname, String studentId,
-                           String imageUrl, List<DepartmentResponse> departmentResponse, boolean isFirstLogin) {
+                           String imageUrl, List<DepartmentResponse> departmentResponse) {
 
-    public static UserResponse of(Long id, String oauthId, String loginId, String email, String nickname, String studentId, String imageUrl, List<DepartmentResponse> departmentResponse, boolean isFirstLogin) {
-        return new UserResponse(id, oauthId, loginId, email, nickname, studentId, imageUrl, departmentResponse, isFirstLogin);
+    public static UserResponse of(Long id, String oauthId, String loginId, String email, String nickname, String studentId, String imageUrl, List<DepartmentResponse> departmentResponse) {
+        return new UserResponse(id, oauthId, loginId, email, nickname, studentId, imageUrl, departmentResponse);
     }
 }

--- a/src/main/java/ku_rum/backend/global/config/SecurityConfig.java
+++ b/src/main/java/ku_rum/backend/global/config/SecurityConfig.java
@@ -4,10 +4,10 @@ import ku_rum.backend.domain.oauth.application.CustomOAuth2UserService;
 import ku_rum.backend.domain.oauth.handler.HttpCookieOAuth2AuthorizationRequestRepository;
 import ku_rum.backend.domain.oauth.handler.OAuth2AuthenticationSuccessHandler;
 import ku_rum.backend.domain.user.domain.repository.UserRepository;
-import ku_rum.backend.global.utill.RedisUtil;
 import ku_rum.backend.global.security.CustomUserDetails;
 import ku_rum.backend.global.security.JwtTokenAuthenticationFilter;
 import ku_rum.backend.global.security.JwtTokenProvider;
+import ku_rum.backend.global.utill.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,7 +32,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.filter.CorsFilter;
 
 import java.util.List;
 
@@ -107,7 +106,8 @@ public class SecurityConfig {
                 .map(u -> CustomUserDetails.of(u.getId(),
                         u.getEmail(),
                         AuthorityUtils.createAuthorityList(u.getRoles().toArray(new String[0])),
-                        u.getPassword()))
+                        u.getPassword(),
+                        u.isFirstLogin()))
                 .orElseThrow(() -> new UsernameNotFoundException(NO_SUCH_USER.getMessage()));
     }
 

--- a/src/main/java/ku_rum/backend/global/security/CustomUserDetails.java
+++ b/src/main/java/ku_rum/backend/global/security/CustomUserDetails.java
@@ -22,29 +22,32 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
     private Collection<? extends GrantedAuthority> roles;
     private String password;
     private Map<String, Object> attributes;
+    private boolean firstLogin;
 
-    private CustomUserDetails(Long userId, String username, Collection<? extends GrantedAuthority> role, String password) {
+    private CustomUserDetails(Long userId, String username, Collection<? extends GrantedAuthority> role, String password, boolean firstLogin) {
         this.userId = userId;
         this.username = username;
         this.email = email;
         this.roles = role;
         this.password = password;
+        this.firstLogin = firstLogin;
     }
 
-    private CustomUserDetails(Long userId, String username, String email, Collection<? extends GrantedAuthority> roles, String password) {
+    private CustomUserDetails(Long userId, String username, String email, Collection<? extends GrantedAuthority> roles, String password, boolean firstLogin) {
         this.userId = userId;
         this.username = username;
         this.email = email;
         this.roles = roles;
         this.password = password;
+        this.firstLogin = firstLogin;
     }
 
-    public static CustomUserDetails of(Long id, String username, Collection<? extends GrantedAuthority> role, String password) {
-        return new CustomUserDetails(id, username, role, password);
+    public static CustomUserDetails of(Long id, String username, Collection<? extends GrantedAuthority> role, String password, boolean firstLogin) {
+        return new CustomUserDetails(id, username, role, password, firstLogin);
     }
 
-    public static CustomUserDetails of(Long id, String username, String email, Collection<? extends GrantedAuthority> roles, String password) {
-        return new CustomUserDetails(id, username, email, roles, password);
+    public static CustomUserDetails of(Long id, String username, String email, Collection<? extends GrantedAuthority> roles, String password, boolean firstLogin) {
+        return new CustomUserDetails(id, username, email, roles, password, firstLogin);
     }
 
     public static CustomUserDetails from(User user) {
@@ -53,7 +56,8 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
                 user.getNickname(),
                 user.getEmail(),
                 AuthorityUtils.createAuthorityList("ROLE_USER"),
-                user.getPassword()
+                user.getPassword(),
+                user.isFirstLogin()
         );
     }
 

--- a/src/main/java/ku_rum/backend/global/security/JwtTokenProvider.java
+++ b/src/main/java/ku_rum/backend/global/security/JwtTokenProvider.java
@@ -46,11 +46,14 @@ public class JwtTokenProvider {
         String refreshToken = createToken(claims, getRefreshValidTime());
         setRedisData(claims, refreshToken);
 
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+
         return TokenResponse.of(
                 accessToken,
                 refreshToken,
                 this.jwtProperties.getAccessTokenValiditySeconds(),
-                this.jwtProperties.getRefreshTokenValiditySeconds());
+                this.jwtProperties.getRefreshTokenValiditySeconds(),
+                userDetails.isFirstLogin());
     }
 
     public Authentication getAuthentication(String token) {
@@ -59,7 +62,8 @@ public class JwtTokenProvider {
         Long userId = claims.get("userPK", Long.class);
         Collection<? extends GrantedAuthority> roles = getGrantedAuthorities(claims);
 
-        CustomUserDetails principal = CustomUserDetails.of(userId, "", roles, "");
+        boolean firstLogin = claims.get("firstLogin", Boolean.class);
+        CustomUserDetails principal = CustomUserDetails.of(userId, "", roles, "", firstLogin);
         return new UsernamePasswordAuthenticationToken(principal, token, roles);
     }
 
@@ -138,7 +142,8 @@ public class JwtTokenProvider {
     }
 
     private Claims getClaimsInUserDetails(CustomUserDetails userDetails, Collection<? extends GrantedAuthority> authorities) {
-        var claimsBuilder = Jwts.claims().add("userPK", userDetails.getUserId());
+        var claimsBuilder = Jwts.claims().add("userPK", userDetails.getUserId())
+                .add("firstLogin", userDetails.isFirstLogin());
 
         if (!authorities.isEmpty()) {
             claimsBuilder.add(AUTHORITIES_KEY, authorities.stream()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ logging:
 app:
   oauth2:
     authorizedRedirectUris:
-      - http://localhost:5173
+      - https://kuroom.shop/oauth/callback
 
 ---
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ logging:
 app:
   oauth2:
     authorizedRedirectUris:
-      - https://kuroom.shop/oauth/callback
+      - https://ku-room.vercel.app/oauth/callback
 
 ---
 spring:

--- a/src/test/java/ku_rum/backend/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/ku_rum/backend/domain/auth/application/AuthServiceTest.java
@@ -4,15 +4,12 @@ import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.HttpServletRequest;
 import ku_rum.backend.domain.auth.dto.request.LoginRequest;
 import ku_rum.backend.domain.auth.dto.request.ReissueRequest;
-import ku_rum.backend.domain.auth.dto.response.AuthResponse;
 import ku_rum.backend.domain.common.firebase.application.NotificationService;
-import ku_rum.backend.domain.user.domain.User;
 import ku_rum.backend.domain.user.domain.repository.UserRepository;
-import ku_rum.backend.domain.user.dto.response.UserResponse;
+import ku_rum.backend.domain.user.dto.response.TokenResponse;
 import ku_rum.backend.global.security.CustomUserDetails;
 import ku_rum.backend.global.security.JwtTokenAuthenticationFilter;
 import ku_rum.backend.global.security.JwtTokenProvider;
-import ku_rum.backend.domain.user.dto.response.TokenResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,10 +20,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
-
-import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -107,7 +101,7 @@ class AuthServiceTest {
         ReissueRequest reissueRequest = new ReissueRequest("valid-refresh-token");
         Authentication authentication = mock(Authentication.class);
         CustomUserDetails userDetails = mock(CustomUserDetails.class);
-        TokenResponse expectedTokenResponse = TokenResponse.of("new-access-token", "new-refresh-token", 10480000, 20400000);
+        TokenResponse expectedTokenResponse = TokenResponse.of("new-access-token", "new-refresh-token", 10480000, 20400000, false);
 
         when(jwtTokenProvider.validateToken("valid-refresh-token")).thenReturn(true);
         when(jwtTokenProvider.getAuthentication("valid-refresh-token")).thenReturn(authentication);

--- a/src/test/java/ku_rum/backend/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/auth/presentation/AuthControllerTest.java
@@ -58,7 +58,7 @@ class AuthControllerTest extends RestDocsTestSupport {
         // UserResponse 설정 (사용자 정보도 포함해야 하므로, 예시로 넣음)
         UserResponse userResponse = UserResponse.of(
                 1L, "oauthId", "kmw10693", "email@example.com", "nickname", "studentId", "imageUrl"
-        , departmentResponses, true);
+        , departmentResponses);
 
         // AuthResponse 설정
         AuthResponse authResponse = AuthResponse.of(tokenResponse, userResponse);
@@ -144,7 +144,7 @@ class AuthControllerTest extends RestDocsTestSupport {
                                                 fieldWithPath("data.userResponse.departmentResponse")
                                                         .type(JsonType.STRING)
                                                         .description("사용자 학과"),
-                                                fieldWithPath("data.userResponse.isFirstLogin")
+                                                fieldWithPath("data.tokenResponse.isFirstLogin")
                                                         .type(JsonType.BOOLEAN)
                                                         .description("사용자 최초 로그인 여부")
                                         ).build())));
@@ -239,7 +239,10 @@ class AuthControllerTest extends RestDocsTestSupport {
                                                         .description("엑세스 토큰 만료 기간"),
                                                 fieldWithPath("data.refreshExpireIn")
                                                         .type(JsonType.STRING)
-                                                        .description("리프레시 토큰 만료 기간")
+                                                        .description("리프레시 토큰 만료 기간"),
+                                                fieldWithPath("data.isFirstLogin")
+                                                        .type(JsonType.BOOLEAN)
+                                                        .description("사용자 최초 로그인 여부")
                                         ).build())));
     }
 
@@ -250,7 +253,7 @@ class AuthControllerTest extends RestDocsTestSupport {
         // given
         String tempToken = "temporary_token_value";
         List<DepartmentResponse> list = new ArrayList<>();
-        UserResponse userResponse = new UserResponse(1L, "oauthId", "loginId", "email", "nickname", "studentId", "imageUrl", list, true);
+        UserResponse userResponse = new UserResponse(1L, "oauthId", "loginId", "email", "nickname", "studentId", "imageUrl", list);
         TokenResponse tokenResponse = new TokenResponse("accessToken", "refreshToken", 1800000L, 604800000L, false);
         AuthResponse authResponse = new AuthResponse(
                 tokenResponse,
@@ -300,7 +303,8 @@ class AuthControllerTest extends RestDocsTestSupport {
                                                 fieldWithPath("data.userResponse.studentId").description("사용자 학생 ID"),
                                                 fieldWithPath("data.userResponse.imageUrl").description("사용자 이미지 URL"),
                                                 fieldWithPath("data.userResponse.departmentResponse").description("사용자 학과 정보"),
-                                                fieldWithPath("data.userResponse.isFirstLogin").description("사용자 최초 로그인 여부")
+                                                fieldWithPath("data.tokenResponse.isFirstLogin").description("사용자 최초 로그인 여부")
+
                                         )
                                         .build()
                         )

--- a/src/test/java/ku_rum/backend/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/auth/presentation/AuthControllerTest.java
@@ -53,7 +53,7 @@ class AuthControllerTest extends RestDocsTestSupport {
         LoginRequest request = new LoginRequest("kmw10693", "testtest");
 
         // TokenResponse 설정
-        TokenResponse tokenResponse = TokenResponse.of("accessToken", "refreshToken", 1800000L, 604800000L);
+        TokenResponse tokenResponse = TokenResponse.of("accessToken", "refreshToken", 1800000L, 604800000L, false);
         List<DepartmentResponse> departmentResponses = List.of();
         // UserResponse 설정 (사용자 정보도 포함해야 하므로, 예시로 넣음)
         UserResponse userResponse = UserResponse.of(
@@ -195,7 +195,7 @@ class AuthControllerTest extends RestDocsTestSupport {
     @WithMockUser
     void reissue() throws Exception {
         ReissueRequest request = new ReissueRequest("refreshToken");
-        TokenResponse tokenResponse = TokenResponse.of("accessToken", "refreshToken", 1800000L, 604800000L);
+        TokenResponse tokenResponse = TokenResponse.of("accessToken", "refreshToken", 1800000L, 604800000L, false);
         Mockito.when(authService.reissue(request)).thenReturn(tokenResponse);
 
         // when then
@@ -251,7 +251,7 @@ class AuthControllerTest extends RestDocsTestSupport {
         String tempToken = "temporary_token_value";
         List<DepartmentResponse> list = new ArrayList<>();
         UserResponse userResponse = new UserResponse(1L, "oauthId", "loginId", "email", "nickname", "studentId", "imageUrl", list, true);
-        TokenResponse tokenResponse = new TokenResponse("accessToken", "refreshToken", 1800000L, 604800000L);
+        TokenResponse tokenResponse = new TokenResponse("accessToken", "refreshToken", 1800000L, 604800000L, false);
         AuthResponse authResponse = new AuthResponse(
                 tokenResponse,
                 userResponse

--- a/src/test/java/ku_rum/backend/domain/user/application/UserServiceTest.java
+++ b/src/test/java/ku_rum/backend/domain/user/application/UserServiceTest.java
@@ -239,7 +239,7 @@ class UserServiceTest {
 
         userRepository.save(user);
 
-        CustomUserDetails userDetails = CustomUserDetails.of(user.getId(), "testUser", AuthorityUtils.createAuthorityList("ROLE_USER"), "test12345");
+        CustomUserDetails userDetails = CustomUserDetails.of(user.getId(), "testUser", AuthorityUtils.createAuthorityList("ROLE_USER"), "test12345", false);
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(auth);
         NicknameChangeRequest request = new NicknameChangeRequest("abcd1234");
@@ -266,7 +266,7 @@ class UserServiceTest {
         userRepository.save(user);
         userRepository.flush();
 
-        CustomUserDetails userDetails = CustomUserDetails.of(user.getId(), "testUser", AuthorityUtils.createAuthorityList("ROLE_USER"), "test12345");
+        CustomUserDetails userDetails = CustomUserDetails.of(user.getId(), "testUser", AuthorityUtils.createAuthorityList("ROLE_USER"), "test12345", false);
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(auth);
 

--- a/src/test/java/ku_rum/backend/domain/user/presentation/UserControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/user/presentation/UserControllerTest.java
@@ -263,7 +263,7 @@ class UserControllerTest extends RestDocsTestSupport {
     void changeProfile() throws Exception {
         // given
         ProfileChangeRequest profileChangeRequest = new ProfileChangeRequest("test.com");
-        CustomUserDetails userDetails = CustomUserDetails.of(1L, "testUser", AuthorityUtils.createAuthorityList("ROLE_USER"), "test12345");
+        CustomUserDetails userDetails = CustomUserDetails.of(1L, "testUser", AuthorityUtils.createAuthorityList("ROLE_USER"), "test12345", false);
 
         // when then
         mockMvc.perform(patch("/api/v1/users/profile")

--- a/src/test/java/ku_rum/backend/domain/user/presentation/UserProfileControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/user/presentation/UserProfileControllerTest.java
@@ -56,7 +56,7 @@ public class UserProfileControllerTest extends RestDocsTestSupport {
     void changeNickname_Success() throws Exception {
         // Given
         NicknameChangeRequest request = new NicknameChangeRequest("안녕안녕");
-        CustomUserDetails userDetails = CustomUserDetails.of(1L, "testUser", AuthorityUtils.createAuthorityList("ROLE_USER"), "test12345");
+        CustomUserDetails userDetails = CustomUserDetails.of(1L, "testUser", AuthorityUtils.createAuthorityList("ROLE_USER"), "test12345", false);
         String requestBody = new ObjectMapper().writeValueAsString(request);
 
         // When & Then
@@ -150,7 +150,7 @@ public class UserProfileControllerTest extends RestDocsTestSupport {
     void passwordReset() throws Exception {
         // given
         ResetPasswordRequest resetPasswordRequest = new ResetPasswordRequest("test1234", "test12345");
-        CustomUserDetails userDetails = CustomUserDetails.of(1L, "testUser", AuthorityUtils.createAuthorityList("ROLE_USER"), "test12345");
+        CustomUserDetails userDetails = CustomUserDetails.of(1L, "testUser", AuthorityUtils.createAuthorityList("ROLE_USER"), "test12345", false);
 
         // when then
         mockMvc.perform(post("/api/v1/users/password-reset")

--- a/src/test/java/ku_rum/backend/global/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/ku_rum/backend/global/security/jwt/JwtTokenProviderTest.java
@@ -60,7 +60,7 @@ class JwtTokenProviderTest {
         Authentication authentication = new UsernamePasswordAuthenticationToken(
                 CustomUserDetails.of(1L, "test", "test",
                         authorities,
-                        "test"
+                        "test", false
                 ), null, authorities);
 
         // When
@@ -134,7 +134,7 @@ class JwtTokenProviderTest {
         Authentication authentication = new UsernamePasswordAuthenticationToken(
                 CustomUserDetails.of(1L, "test", "test",
                         authorities,
-                        "test"
+                        "test", false
                 ), null, authorities);
 
         doThrow(new RuntimeException("Redis error")).when(redisUtil)
@@ -155,7 +155,7 @@ class JwtTokenProviderTest {
                 "test",
                 "test",
                 authorities,
-                "test"
+                "test",false
         );
 
         Authentication authentication = new UsernamePasswordAuthenticationToken(


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closes #이슈번호 입력해주세요.

## 📝작업 내용
- [ ] 작업1
- [ ] 작업2
- [ ] 작업3

## 작업 상세 내용
상세 내용을 입력해주세요.

## 💬리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 로그인 응답에 첫 로그인 여부(firstLogin)를 추가하여 클라이언트가 온보딩 등 초기 동작을 구분할 수 있습니다.
  - JWT에 firstLogin 클레임이 포함되어 인증 재구성 시 상태가 유지됩니다.
- 변경
  - OAuth 리디렉션 URL을 https://ku-room.vercel.app/oauth/callback 으로 업데이트했습니다.
  - OAuth로 생성된 계정은 이메일 정보가 제공되지 않을 수 있습니다(이 경우 이메일 필드 비어있음).
- 주의 사항
  - TokenResponse 형식이 변경되어 클라이언트에서 firstLogin 필드 파싱 및 처리 필요합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->