### PR TITLE
[FIX] 랭킹 공통 등수 변경

### DIFF
--- a/src/main/java/ku_rum/backend/domain/friend/application/FriendQueryService.java
+++ b/src/main/java/ku_rum/backend/domain/friend/application/FriendQueryService.java
@@ -1,5 +1,8 @@
 package ku_rum.backend.domain.friend.application;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import ku_rum.backend.domain.friend.domain.Friend;
 import ku_rum.backend.domain.friend.domain.repository.FriendRepository;
 import ku_rum.backend.domain.friend.domain.vo.FriendStatus;
@@ -7,16 +10,16 @@ import ku_rum.backend.domain.friend.dto.response.FriendListResponse;
 import ku_rum.backend.domain.friend.dto.response.FriendSearchResponse;
 import ku_rum.backend.domain.friend.dto.response.ReceivedFriendResponse;
 import ku_rum.backend.domain.friend.dto.response.SentFriendResponse;
+import ku_rum.backend.domain.user.application.UserQueryService;
 import ku_rum.backend.domain.user.domain.User;
 import ku_rum.backend.domain.user.domain.repository.UserRepository;
+import ku_rum.backend.global.exception.global.GlobalException;
+import ku_rum.backend.global.security.CustomUserDetails;
+import ku_rum.backend.global.support.status.BaseExceptionResponseStatus;
 import ku_rum.backend.global.utill.UserUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Service
 @Transactional(readOnly = true)
@@ -26,6 +29,7 @@ public class FriendQueryService {
     private final FriendRepository friendRepository;
     private final UserRepository userRepository;
     private final UserUtil userUtil;
+    private final UserQueryService userQueryService;
 
     // 친구 목록 조회
     public List<FriendListResponse> getFriendList() {
@@ -75,10 +79,12 @@ public class FriendQueryService {
                 .collect(Collectors.toList());
 
         // 1. 친구 요청을 보낸 사용자 ID 리스트 (PENDING)
-        List<Long> sentRequestUserIds = friendRepository.findToUserIdsByFromUserAndStatus(currentUser.getId(), targetUserIds, FriendStatus.PENDING);
+        List<Long> sentRequestUserIds = friendRepository.findToUserIdsByFromUserAndStatus(currentUser.getId(),
+                targetUserIds, FriendStatus.PENDING);
 
         // 2. 친구인 사용자 ID 리스트 (ACCEPTED 양방향)
-        List<Long> friendUserIds = friendRepository.findFriendUserIds(currentUser.getId(), targetUserIds, FriendStatus.ACCEPT);
+        List<Long> friendUserIds = friendRepository.findFriendUserIds(currentUser.getId(), targetUserIds,
+                FriendStatus.ACCEPT);
 
         return matchedUsers.stream()
                 .map(user -> new FriendSearchResponse(
@@ -89,5 +95,18 @@ public class FriendQueryService {
                         friendUserIds.contains(user.getId())
                 ))
                 .collect(Collectors.toList());
+    }
+
+    public void validateFriend(CustomUserDetails userDetails, Long friendId) {
+        User currentUser = userUtil.getUser();
+        User targetUser = userQueryService.getUserById(friendId);
+
+        boolean isFriend =
+                friendRepository.existsByFromUserAndToUserAndStatus(currentUser, targetUser, FriendStatus.ACCEPT) ||
+                        friendRepository.existsByFromUserAndToUserAndStatus(targetUser, currentUser,
+                                FriendStatus.ACCEPT);
+        if (!isFriend) {
+            throw new GlobalException(BaseExceptionResponseStatus.NO_FRIEND_REQUEST);
+        }
     }
 }

--- a/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
+++ b/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
+import ku_rum.backend.domain.friend.application.FriendQueryService;
 import ku_rum.backend.domain.place.domain.Place;
 import ku_rum.backend.domain.rank.application.response.GetPlaceUserRankResponse;
 import ku_rum.backend.domain.rank.application.response.PlaceUserRankResponse;
@@ -30,6 +31,7 @@ public class RankService {
 
     private final PlaceRankRepository placeRankRepository;
     private final UserService userService;
+    private final FriendQueryService friendQueryService;
 
     /**
      * 유저 장소 공유 랭킹 조회(3개)
@@ -104,6 +106,7 @@ public class RankService {
     }
 
     public List<GetPlaceUserRankResponse> getPlaceFriendRank(CustomUserDetails userDetails, Long friendId) {
+        friendQueryService.validateFriend(userDetails, friendId);
         List<PlaceRank> PlaceRanks = placeRankRepository.findTop3RanksWithTiesByUser(friendId);
 
         Map<Integer, List<PlaceRank>> placeRanksGroupedByCount = PlaceRanks.stream()

--- a/src/main/java/ku_rum/backend/domain/rank/domain/repository/PlaceRankRepository.java
+++ b/src/main/java/ku_rum/backend/domain/rank/domain/repository/PlaceRankRepository.java
@@ -44,7 +44,7 @@ public interface PlaceRankRepository extends JpaRepository<PlaceRank, Long> {
                 FROM (
                     SELECT 
                         pr.*, 
-                        RANK() OVER (ORDER BY pr.count DESC) AS ranking
+                        DENSE_RANK() OVER (ORDER BY pr.count DESC) AS ranking
                     FROM place_rank pr
                     WHERE place_place_id =:placeId
                 ) ranked

--- a/src/main/java/ku_rum/backend/domain/rank/presentation/RankController.java
+++ b/src/main/java/ku_rum/backend/domain/rank/presentation/RankController.java
@@ -27,7 +27,8 @@ public class RankController {
 
     @GetMapping("/users/ranks/{friendId}")
     public BaseResponse<List<GetPlaceUserRankResponse>> getPlaceFriendRank(
-            @AuthenticationPrincipal final CustomUserDetails userDetails, @PathVariable final Long friendId) {
+            @AuthenticationPrincipal final CustomUserDetails userDetails,
+            @PathVariable("friendId") final Long friendId) {
         return BaseResponse.ok(rankService.getPlaceFriendRank(userDetails, friendId));
     }
 }

--- a/src/test/java/ku_rum/backend/domain/rank/presentation/RankControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/rank/presentation/RankControllerTest.java
@@ -68,16 +68,16 @@ public class RankControllerTest extends RestDocsTestSupport {
     void getPlaceFriendRank() throws Exception {
         //given
         String placeName = "상허기념도서관";
-        Long placeId = 2L;
+        Long friendId = 2L;
         int count = 5;
         GetPlaceUserRankResponse getPlaceUserRankResponse = new GetPlaceUserRankResponse(List.of(placeName), count);
         List<GetPlaceUserRankResponse> response = List.of(getPlaceUserRankResponse);
 
-        given(rankService.getPlaceFriendRank(any(CustomUserDetails.class), eq(placeId)))
+        given(rankService.getPlaceFriendRank(any(CustomUserDetails.class), eq(friendId)))
                 .willReturn(response);
 
         //when
-        mockMvc.perform(get("/api/v1/places/users/ranks/{placeId}", placeId)
+        mockMvc.perform(get("/api/v1/places/users/ranks/{friendId}", friendId)
                         .header("Authorization",
                                 "Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyUEsiOjEsInJvbGVzIjoiUk9MRV9VU0VSIiwiaWF0IjoxNzQwMjQyNjQxLCJleHAiOjE3NDAyNDQ0NDF9.kLSMBLWdvIvrBpㄴGJdOigSKjxMIab0cV06xFjSpwrq70"))
                 //then
@@ -91,7 +91,7 @@ public class RankControllerTest extends RestDocsTestSupport {
                                         headerWithName("Authorization").description("발급 받은 엑세스 토큰입니다.")
                                 )
                                 .pathParameters(
-                                        RequestDocumentation.parameterWithName("placeId").description("건물id")
+                                        RequestDocumentation.parameterWithName("friendId").description("친구id")
                                 )
                                 .build())));
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closes #313 

## 📝작업 내용
- [x] 공통등수 로직 변경
- [x] 친구 랭킹 조회 Validate 추가

## 작업 상세 내용
상세 내용을 입력해주세요.

## 💬리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 버그 수정
  - 친구 랭킹 조회 시, 두 사용자가 상호 수락된 친구 관계일 때만 접근되도록 검증을 추가하여 잘못된 조회를 방지했습니다.
  - 장소 랭킹에서 동점 처리 방식을 변경해 상위 3위 노출의 일관성을 향상시켰습니다.

- 리팩터링
  - 경로 변수의 명시적 바인딩을 도입해 요청 파라미터 해석 안정성을 개선했습니다.

- 테스트
  - 친구 랭킹 조회 경로와 파라미터 명 변경을 반영해 관련 테스트와 문서를 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->