### PR TITLE
[Feat] 랭킹 페이징 API

### DIFF
--- a/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
+++ b/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
@@ -125,6 +125,7 @@ public class RankService {
 
     public List<GetPlaceRankResponse> getPlaceRanks(CustomUserDetails customUserDetails, Long placeId, int startRank,
                                                     int endRank) {
+        validateRankRange(startRank, endRank);
         User user = userService.getUser();
         List<PlaceRankWithRankingProjection> placeRankWithRankings = placeRankRepository.findRankByRange(placeId,
                 startRank,
@@ -141,5 +142,11 @@ public class RankService {
                 .stream()
                 .map(placeRanks -> GetPlaceRankResponse.from(placeRanks, user))
                 .toList();
+    }
+
+    private void validateRankRange(int startRank, int endRank) {
+        if (startRank < 1 || endRank < 1 || startRank > endRank) {
+            throw new GlobalException(BaseExceptionResponseStatus.INVALID_RANK_RANGE);
+        }
     }
 }

--- a/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
+++ b/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
@@ -10,6 +10,7 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 import ku_rum.backend.domain.friend.application.FriendQueryService;
 import ku_rum.backend.domain.place.domain.Place;
+import ku_rum.backend.domain.rank.application.response.GetPlaceRankResponse;
 import ku_rum.backend.domain.rank.application.response.GetPlaceUserRankResponse;
 import ku_rum.backend.domain.rank.application.response.PlaceUserRankResponse;
 import ku_rum.backend.domain.rank.domain.PlaceRank;
@@ -119,6 +120,26 @@ public class RankService {
         return placeRanksGroupedByCount.values()
                 .stream()
                 .map(GetPlaceUserRankResponse::from)
+                .toList();
+    }
+
+    public List<GetPlaceRankResponse> getPlaceRanks(CustomUserDetails customUserDetails, Long placeId, int startRank,
+                                                    int endRank) {
+        User user = userService.getUser();
+        List<PlaceRankWithRankingProjection> placeRankWithRankings = placeRankRepository.findRankByRange(placeId,
+                startRank,
+                endRank);
+
+        Map<Integer, List<PlaceRankWithRankingProjection>> placeRanksGroupedByCount = placeRankWithRankings.stream()
+                .collect(Collectors.groupingBy(
+                        PlaceRankWithRankingProjection::getRanking,
+                        TreeMap::new,
+                        toList())
+                );
+
+        return placeRanksGroupedByCount.values()
+                .stream()
+                .map(placeRanks -> GetPlaceRankResponse.from(placeRanks, user))
                 .toList();
     }
 }

--- a/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
+++ b/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
@@ -34,6 +34,8 @@ public class RankService {
     private final UserService userService;
     private final FriendQueryService friendQueryService;
 
+    private static final int MIN_RANK = 1;
+
     /**
      * 유저 장소 공유 랭킹 조회(3개)
      *
@@ -145,7 +147,7 @@ public class RankService {
     }
 
     private void validateRankRange(int startRank, int endRank) {
-        if (startRank < 1 || endRank < 1 || startRank > endRank) {
+        if (startRank < MIN_RANK || endRank < MIN_RANK || startRank > endRank) {
             throw new GlobalException(BaseExceptionResponseStatus.INVALID_RANK_RANGE);
         }
     }

--- a/src/main/java/ku_rum/backend/domain/rank/application/response/GetPlaceRankResponse.java
+++ b/src/main/java/ku_rum/backend/domain/rank/application/response/GetPlaceRankResponse.java
@@ -10,26 +10,32 @@ import ku_rum.backend.global.support.status.BaseExceptionResponseStatus;
 public record GetPlaceRankResponse(int ranking, List<String> nickname, int sharingCount, boolean isSelf) {
 
     public static GetPlaceRankResponse from(List<PlaceRankWithRankingProjection> placeRanks, User user) {
+        validatePlaceRanks(placeRanks);
+
+        List<String> names = extractSortedNicknames(placeRanks);
+
+        PlaceRankWithRankingProjection firstRank = placeRanks.get(0);
+
+        boolean isSelf = containsUserNickname(placeRanks, user);
+
+        return new GetPlaceRankResponse(firstRank.getRanking(), names, firstRank.getCount(), isSelf);
+    }
+
+    private static void validatePlaceRanks(List<PlaceRankWithRankingProjection> placeRanks) {
         if (placeRanks.isEmpty()) {
             throw new GlobalException(BaseExceptionResponseStatus.RANK_NOT_FOUND);
         }
+    }
 
-        List<String> names = placeRanks.stream()
+    private static List<String> extractSortedNicknames(List<PlaceRankWithRankingProjection> placeRanks) {
+        return placeRanks.stream()
                 .sorted(Comparator.comparing(PlaceRankWithRankingProjection::getModifiedAt))
-                .map(placeRankWithRankingProjection -> placeRankWithRankingProjection.getNickname())
+                .map(PlaceRankWithRankingProjection::getNickname)
                 .toList();
+    }
 
-        int count = placeRanks.stream()
-                .findFirst()
-                .get()
-                .getCount();
-
-        boolean isSelf = placeRanks.stream()
-                .findFirst()
-                .map(placeRankWithRankingProjection -> placeRankWithRankingProjection.getNickname()
-                        .equals(user.getNickname()))
-                .orElse(false);
-
-        return new GetPlaceRankResponse(placeRanks.get(0).getRanking(), names, count, isSelf);
+    private static boolean containsUserNickname(List<PlaceRankWithRankingProjection> placeRanks, User user) {
+        return placeRanks.stream()
+                .anyMatch(rank -> rank.getNickname().equals(user.getNickname()));
     }
 }

--- a/src/main/java/ku_rum/backend/domain/rank/application/response/GetPlaceRankResponse.java
+++ b/src/main/java/ku_rum/backend/domain/rank/application/response/GetPlaceRankResponse.java
@@ -1,0 +1,35 @@
+package ku_rum.backend.domain.rank.application.response;
+
+import java.util.Comparator;
+import java.util.List;
+import ku_rum.backend.domain.rank.dto.PlaceRankWithRankingProjection;
+import ku_rum.backend.domain.user.domain.User;
+import ku_rum.backend.global.exception.global.GlobalException;
+import ku_rum.backend.global.support.status.BaseExceptionResponseStatus;
+
+public record GetPlaceRankResponse(int ranking, List<String> nickname, int sharingCount, boolean isSelf) {
+
+    public static GetPlaceRankResponse from(List<PlaceRankWithRankingProjection> placeRanks, User user) {
+        if (placeRanks.isEmpty()) {
+            throw new GlobalException(BaseExceptionResponseStatus.RANK_NOT_FOUND);
+        }
+
+        List<String> names = placeRanks.stream()
+                .sorted(Comparator.comparing(PlaceRankWithRankingProjection::getModifiedAt))
+                .map(placeRankWithRankingProjection -> placeRankWithRankingProjection.getNickname())
+                .toList();
+
+        int count = placeRanks.stream()
+                .findFirst()
+                .get()
+                .getCount();
+
+        boolean isSelf = placeRanks.stream()
+                .findFirst()
+                .map(placeRankWithRankingProjection -> placeRankWithRankingProjection.getNickname()
+                        .equals(user.getNickname()))
+                .orElse(false);
+
+        return new GetPlaceRankResponse(placeRanks.get(0).getRanking(), names, count, isSelf);
+    }
+}

--- a/src/main/java/ku_rum/backend/domain/rank/domain/repository/PlaceRankRepository.java
+++ b/src/main/java/ku_rum/backend/domain/rank/domain/repository/PlaceRankRepository.java
@@ -68,4 +68,29 @@ public interface PlaceRankRepository extends JpaRepository<PlaceRank, Long> {
                 WHERE po.position_id IN (:positionIds)
             """, nativeQuery = true)
     void updatePlaceRankByPositions(@Param("positionIds") List<Long> positionIds);
+
+    @Query(value = """
+                SELECT 
+                    ranked.rank_id          AS rankId,
+                    ranked.count            AS count,
+                    u.nickname              AS nickname,
+                    ranked.place_place_id   AS placePlaceId,
+                    ranked.created_at       AS createdAt,
+                    ranked.modified_at      AS modifiedAt,
+                    ranked.ranking          AS ranking
+                FROM (
+                    SELECT 
+                        pr.*, 
+                        DENSE_RANK() OVER (ORDER BY pr.count DESC) AS ranking
+                    FROM place_rank pr
+                    WHERE place_place_id =:placeId
+                ) ranked
+                JOIN users u
+                            ON u.id = ranked.user_id
+                WHERE ranking >= :startRank AND ranking <= :endRank
+                ORDER BY ranking
+            """, nativeQuery = true)
+    List<PlaceRankWithRankingProjection> findRankByRange(@Param("placeId") Long placeId,
+                                                         @Param("startRank") int startRank,
+                                                         @Param("endRank") int endRank);
 }

--- a/src/main/java/ku_rum/backend/domain/rank/presentation/RankController.java
+++ b/src/main/java/ku_rum/backend/domain/rank/presentation/RankController.java
@@ -37,9 +37,9 @@ public class RankController {
     @GetMapping("/ranks/{placeId}")
     public BaseResponse<List<GetPlaceRankResponse>> getPlaceRank(
             @AuthenticationPrincipal final CustomUserDetails userDetails,
-            @PathVariable("placeId") Long placeId,
-            @RequestParam("startRank") int startRank,
-            @RequestParam("endRank") int endRank) {
+            @PathVariable("placeId") final Long placeId,
+            @RequestParam("startRank") final int startRank,
+            @RequestParam("endRank") final int endRank) {
         return BaseResponse.ok(rankService.getPlaceRanks(userDetails, placeId, startRank, endRank));
     }
 

--- a/src/main/java/ku_rum/backend/domain/rank/presentation/RankController.java
+++ b/src/main/java/ku_rum/backend/domain/rank/presentation/RankController.java
@@ -2,6 +2,7 @@ package ku_rum.backend.domain.rank.presentation;
 
 import java.util.List;
 import ku_rum.backend.domain.rank.application.RankService;
+import ku_rum.backend.domain.rank.application.response.GetPlaceRankResponse;
 import ku_rum.backend.domain.rank.application.response.GetPlaceUserRankResponse;
 import ku_rum.backend.global.security.CustomUserDetails;
 import ku_rum.backend.global.support.response.BaseResponse;
@@ -10,6 +11,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -31,4 +33,14 @@ public class RankController {
             @PathVariable("friendId") final Long friendId) {
         return BaseResponse.ok(rankService.getPlaceFriendRank(userDetails, friendId));
     }
+
+    @GetMapping("/ranks/{placeId}")
+    public BaseResponse<List<GetPlaceRankResponse>> getPlaceRank(
+            @AuthenticationPrincipal final CustomUserDetails userDetails,
+            @PathVariable("placeId") Long placeId,
+            @RequestParam("startRank") int startRank,
+            @RequestParam("endRank") int endRank) {
+        return BaseResponse.ok(rankService.getPlaceRanks(userDetails, placeId, startRank, endRank));
+    }
+
 }

--- a/src/main/java/ku_rum/backend/global/support/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/ku_rum/backend/global/support/status/BaseExceptionResponseStatus.java
@@ -124,7 +124,9 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     UNSUPPORTED_FRIEND_CHIP_ERROR(1202, HttpStatus.UNAUTHORIZED, "비회원으로 친구를 조회할 수 없습니다"),
     PLACE_RANK_NOT_FOUND(1203, HttpStatus.NOT_FOUND, "해당되는 랭크장소가 없습니다."),
     PLACE_BUILDING_NOT_FOUND(1204, HttpStatus.NOT_FOUND, "해당 위치가 속한 건물이 없습니다."),
-    RANK_NOT_FOUND(1205, HttpStatus.NOT_FOUND, "랭크가 없습니다");
+    RANK_NOT_FOUND(1205, HttpStatus.NOT_FOUND, "랭크가 없습니다"),
+    INVALID_RANK_RANGE(1206, HttpStatus.BAD_REQUEST, "잘못된 랭킹입니다"),
+    ;
 
     private final int code;
     private final HttpStatus status;

--- a/src/test/java/ku_rum/backend/domain/rank/presentation/RankControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/rank/presentation/RankControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -13,17 +14,21 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import java.util.List;
 import ku_rum.backend.config.RestDocsTestSupport;
 import ku_rum.backend.domain.rank.application.RankService;
+import ku_rum.backend.domain.rank.application.response.GetPlaceRankResponse;
 import ku_rum.backend.domain.rank.application.response.GetPlaceUserRankResponse;
+import ku_rum.backend.global.domain.repository.ApiLogRepository;
 import ku_rum.backend.global.security.CustomUserDetails;
+import ku_rum.backend.global.security.JwtTokenAuthenticationFilter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.request.RequestDocumentation;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
+@WebMvcTest(RankController.class)
 @ActiveProfiles("test")
 public class RankControllerTest extends RestDocsTestSupport {
 
@@ -31,7 +36,13 @@ public class RankControllerTest extends RestDocsTestSupport {
     RankService rankService;
 
     @MockBean
+    private ApiLogRepository apiLogRepository;
+
+    @MockBean
     private SecurityFilterChain securityFilterChain;
+
+    @MockBean
+    private JwtTokenAuthenticationFilter jwtTokenAuthenticationFilter;
 
     @DisplayName("장소 공유 순위를 확인한다")
     @Test
@@ -95,5 +106,58 @@ public class RankControllerTest extends RestDocsTestSupport {
                                 )
                                 .build())));
 
+    }
+
+    @DisplayName("특정 장소의 랭킹을 구간별로 조회한다")
+    @Test
+    @WithMockUser(username = "testUser", roles = {"USER"})
+    void getPlaceRank() throws Exception {
+        // given
+        Long placeId = 75L;
+        int startRank = 1;
+        int endRank = 10;
+
+        List<GetPlaceRankResponse> response = List.of(
+                new GetPlaceRankResponse(2, List.of("테스트8"), 8, false),
+                new GetPlaceRankResponse(3, List.of("테스트7"), 7, false),
+                new GetPlaceRankResponse(4, List.of("테스트6"), 6, false)
+        );
+
+        given(rankService.getPlaceRanks(any(), eq(placeId), eq(startRank), eq(endRank)))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/places/ranks/{placeId}", placeId)
+                        .param("startRank", String.valueOf(startRank))
+                        .param("endRank", String.valueOf(endRank))
+                        .header("Authorization",
+                                "Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyUEsiOjEsInJvbGVzIjoiUk9MRV9VU0VSIiwiaWF0IjoxNzQwMjQyNjQxLCJleHAiOjE3NDAyNDQ0NDF9.kLSMBLWdvIvrBpㄴGJdOigSKjxMIab0cV06xFjSpwrq70"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("랭킹 관련 API")
+                                .description("특정 장소의 랭킹을 구간별로 조회합니다.")
+                                .requestHeaders(
+                                        headerWithName("Authorization").description("발급받은 엑세스 토큰")
+                                )
+                                .pathParameters(
+                                        RequestDocumentation.parameterWithName("placeId").description("조회할 장소의 ID")
+                                )
+                                .queryParameters(
+                                        RequestDocumentation.parameterWithName("startRank").description("조회 시작 랭크"),
+                                        RequestDocumentation.parameterWithName("endRank").description("조회 종료 랭크")
+                                )
+                                .responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("응답 상태"),
+                                        fieldWithPath("message").description("응답 메시지"),
+                                        fieldWithPath("data[].ranking").description("순위"),
+                                        fieldWithPath("data[].nickname").description("닉네임 목록"),
+                                        fieldWithPath("data[].sharingCount").description("공유 횟수"),
+                                        fieldWithPath("data[].isSelf").description("본인 여부")
+                                )
+                                .build()
+                )));
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closes #317 

## 📝작업 내용
- [x] 랭킹 페이징 API 추가

## 작업 상세 내용
- 랭킹 페이징 API 추가했습니다
- 페이징 기준이 랭킹입니다

## 💬리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 특정 순위 범위(startRank/endRank)를 지정해 장소의 순위 목록을 조회하는 새 API 엔드포인트 추가 — 각 항목에 순위, 닉네임 목록, 공유수 및 본인 여부 포함.

* **검증 / 오류 처리**
  * 순위 범위 유효성 검사 추가 — 유효하지 않은 범위 요청 시 400 응답 및 명확한 오류 코드 반환.

* **테스트**
  * 컨트롤러 단위 테스트로 전환하고 해당 엔드포인트에 대한 요청/응답 검증 및 문서화 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->