### PR TITLE
[Feat] 랭킹 관련 API 수정

### DIFF
--- a/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
+++ b/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
@@ -38,6 +38,8 @@ public class RankService {
     private final FriendQueryService friendQueryService;
 
     private static final int MIN_RANK = 1;
+    private static final int TOP_3_START = 1;
+    private static final int TOP_3_END = 3;
 
     /**
      * 유저 장소 공유 랭킹 조회(3개)
@@ -170,7 +172,7 @@ public class RankService {
 
     public List<GetPlaceRankResponse> getPlaceTopRank(Long placeId) {
         List<PlaceRankWithRankingProjection> placeRankWithRankingProjections = placeRankRepository.findRankByRange(
-                placeId, 1, 3);
+                placeId, TOP_3_START, TOP_3_END);
 
         return placeRankWithRankingProjections
                 .stream()

--- a/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
+++ b/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
@@ -149,7 +149,7 @@ public class RankService {
                         toList())
                 );
 
-        List<GetPlaceRankResponse> response = placeRanksGroupedByCount.values()
+        List<GetPlaceRankResponse> response = placeRankWithRankingProjections
                 .stream()
                 .map(placeRanks -> GetPlaceRankResponse.from(placeRanks, user))
                 .toList();

--- a/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
+++ b/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
@@ -141,13 +141,6 @@ public class RankService {
                 .limit(request.limit())
                 .toList();
 
-        Map<Integer, List<PlaceRankWithRankingProjection>> placeRanksGroupedByCount = placeRankWithRankingProjections.stream()
-                .collect(Collectors.groupingBy(
-                        PlaceRankWithRankingProjection::getRanking,
-                        TreeMap::new,
-                        toList())
-                );
-
         List<GetPlaceRankResponse> response = placeRankWithRankingProjections
                 .stream()
                 .map(placeRanks -> GetPlaceRankResponse.from(placeRanks))

--- a/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
+++ b/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
@@ -128,9 +128,8 @@ public class RankService {
                 .toList();
     }
 
-    public GetPlaceRankPaginationResponse getPlaceRanks(CustomUserDetails customUserDetails, Long placeId,
+    public GetPlaceRankPaginationResponse getPlaceRanks(Long placeId,
                                                         PlaceRankPaginationRequest request) {
-        User user = userService.getUser();
         PlaceRankingLastKnownCursor page = PlaceRankingLastKnownCursor.from(request.lastKnown());
 
         List<PlaceRankWithRankingProjection> placeRankWithRankings = placeRankRepository.findRankByRange(placeId,
@@ -151,7 +150,7 @@ public class RankService {
 
         List<GetPlaceRankResponse> response = placeRankWithRankingProjections
                 .stream()
-                .map(placeRanks -> GetPlaceRankResponse.from(placeRanks, user))
+                .map(placeRanks -> GetPlaceRankResponse.from(placeRanks))
                 .toList();
 
         boolean hasNext = placeRankWithRankings.size() > request.limit();

--- a/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
+++ b/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
@@ -10,12 +10,15 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 import ku_rum.backend.domain.friend.application.FriendQueryService;
 import ku_rum.backend.domain.place.domain.Place;
+import ku_rum.backend.domain.rank.application.response.GetPlaceRankPaginationResponse;
 import ku_rum.backend.domain.rank.application.response.GetPlaceRankResponse;
 import ku_rum.backend.domain.rank.application.response.GetPlaceUserRankResponse;
 import ku_rum.backend.domain.rank.application.response.PlaceUserRankResponse;
 import ku_rum.backend.domain.rank.domain.PlaceRank;
 import ku_rum.backend.domain.rank.domain.repository.PlaceRankRepository;
 import ku_rum.backend.domain.rank.dto.PlaceRankWithRankingProjection;
+import ku_rum.backend.domain.rank.dto.PlaceRankingLastKnownCursor;
+import ku_rum.backend.domain.rank.dto.request.PlaceRankPaginationRequest;
 import ku_rum.backend.domain.user.application.UserService;
 import ku_rum.backend.domain.user.domain.User;
 import ku_rum.backend.global.exception.global.GlobalException;
@@ -125,30 +128,40 @@ public class RankService {
                 .toList();
     }
 
-    public List<GetPlaceRankResponse> getPlaceRanks(CustomUserDetails customUserDetails, Long placeId, int startRank,
-                                                    int endRank) {
-        validateRankRange(startRank, endRank);
+    public GetPlaceRankPaginationResponse getPlaceRanks(CustomUserDetails customUserDetails, Long placeId,
+                                                        PlaceRankPaginationRequest request) {
         User user = userService.getUser();
-        List<PlaceRankWithRankingProjection> placeRankWithRankings = placeRankRepository.findRankByRange(placeId,
-                startRank,
-                endRank);
+        PlaceRankingLastKnownCursor page = PlaceRankingLastKnownCursor.from(request.lastKnown());
 
-        Map<Integer, List<PlaceRankWithRankingProjection>> placeRanksGroupedByCount = placeRankWithRankings.stream()
+        List<PlaceRankWithRankingProjection> placeRankWithRankings = placeRankRepository.findRankByRange(placeId,
+                page.lastRank(),
+                page.lastRankId(),
+                request.limit() + 1);
+
+        List<PlaceRankWithRankingProjection> placeRankWithRankingProjections = placeRankWithRankings.stream()
+                .limit(request.limit())
+                .toList();
+
+        Map<Integer, List<PlaceRankWithRankingProjection>> placeRanksGroupedByCount = placeRankWithRankingProjections.stream()
                 .collect(Collectors.groupingBy(
                         PlaceRankWithRankingProjection::getRanking,
                         TreeMap::new,
                         toList())
                 );
 
-        return placeRanksGroupedByCount.values()
+        List<GetPlaceRankResponse> response = placeRanksGroupedByCount.values()
                 .stream()
                 .map(placeRanks -> GetPlaceRankResponse.from(placeRanks, user))
                 .toList();
-    }
 
-    private void validateRankRange(int startRank, int endRank) {
-        if (startRank < MIN_RANK || endRank < MIN_RANK || startRank > endRank) {
-            throw new GlobalException(BaseExceptionResponseStatus.INVALID_RANK_RANGE);
+        boolean hasNext = placeRankWithRankings.size() > request.limit();
+        String nextCursor = null;
+        if (hasNext) {
+            PlaceRankWithRankingProjection lastItem = placeRankWithRankingProjections.get(
+                    placeRankWithRankingProjections.size() - 1);
+            nextCursor = PlaceRankingLastKnownCursor.of(lastItem.getRanking(), lastItem.getRankId())
+                    .toCursorString();
         }
+        return GetPlaceRankPaginationResponse.of(response, hasNext, nextCursor);
     }
 }

--- a/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
+++ b/src/main/java/ku_rum/backend/domain/rank/application/RankService.java
@@ -89,6 +89,17 @@ public class RankService {
                 BaseExceptionResponseStatus.PLACE_RANK_NOT_FOUND));
     }
 
+    public GetPlaceRankResponse getUserPlaceRank(Long userId, Long placeId) {
+        Optional<PlaceRankWithRankingProjection> rankByPlaceAndUser = placeRankRepository.findRankByPlaceAndUser(
+                placeId,
+                userId);
+        if (rankByPlaceAndUser.isEmpty()) {
+            User user = userService.getUser();
+            return GetPlaceRankResponse.emptyFrom(user);
+        }
+        return GetPlaceRankResponse.from(rankByPlaceAndUser.get());
+    }
+
     /**
      * 장소 전체 유저공유 랭킹 조회(3개)
      *
@@ -155,5 +166,15 @@ public class RankService {
                     .toCursorString();
         }
         return GetPlaceRankPaginationResponse.of(response, hasNext, nextCursor);
+    }
+
+    public List<GetPlaceRankResponse> getPlaceTopRank(Long placeId) {
+        List<PlaceRankWithRankingProjection> placeRankWithRankingProjections = placeRankRepository.findRankByRange(
+                placeId, 1, 3);
+
+        return placeRankWithRankingProjections
+                .stream()
+                .map(placeRanks -> GetPlaceRankResponse.from(placeRanks))
+                .toList();
     }
 }

--- a/src/main/java/ku_rum/backend/domain/rank/application/response/GetPlaceRankPaginationResponse.java
+++ b/src/main/java/ku_rum/backend/domain/rank/application/response/GetPlaceRankPaginationResponse.java
@@ -1,0 +1,17 @@
+package ku_rum.backend.domain.rank.application.response;
+
+import java.util.List;
+import lombok.Builder;
+
+
+@Builder
+public record GetPlaceRankPaginationResponse(List<GetPlaceRankResponse> ranks, boolean hasNext, String nextCursor) {
+    public static GetPlaceRankPaginationResponse of(List<GetPlaceRankResponse> response, boolean hasNext,
+                                                    String nextCursor) {
+        return GetPlaceRankPaginationResponse.builder()
+                .ranks(response)
+                .hasNext(hasNext)
+                .nextCursor(nextCursor)
+                .build();
+    }
+}

--- a/src/main/java/ku_rum/backend/domain/rank/application/response/GetPlaceRankResponse.java
+++ b/src/main/java/ku_rum/backend/domain/rank/application/response/GetPlaceRankResponse.java
@@ -4,27 +4,12 @@ import java.util.Comparator;
 import java.util.List;
 import ku_rum.backend.domain.rank.dto.PlaceRankWithRankingProjection;
 import ku_rum.backend.domain.user.domain.User;
-import ku_rum.backend.global.exception.global.GlobalException;
-import ku_rum.backend.global.support.status.BaseExceptionResponseStatus;
 
-public record GetPlaceRankResponse(int ranking, List<String> nickname, int sharingCount, boolean isSelf) {
+public record GetPlaceRankResponse(int ranking, String nickname, int sharingCount) {
 
-    public static GetPlaceRankResponse from(List<PlaceRankWithRankingProjection> placeRanks, User user) {
-        validatePlaceRanks(placeRanks);
+    public static GetPlaceRankResponse from(PlaceRankWithRankingProjection placeRanks, User user) {
 
-        List<String> names = extractSortedNicknames(placeRanks);
-
-        PlaceRankWithRankingProjection firstRank = placeRanks.get(0);
-
-        boolean isSelf = containsUserNickname(placeRanks, user);
-
-        return new GetPlaceRankResponse(firstRank.getRanking(), names, firstRank.getCount(), isSelf);
-    }
-
-    private static void validatePlaceRanks(List<PlaceRankWithRankingProjection> placeRanks) {
-        if (placeRanks.isEmpty()) {
-            throw new GlobalException(BaseExceptionResponseStatus.RANK_NOT_FOUND);
-        }
+        return new GetPlaceRankResponse(placeRanks.getRanking(), placeRanks.getNickname(), placeRanks.getCount());
     }
 
     private static List<String> extractSortedNicknames(List<PlaceRankWithRankingProjection> placeRanks) {
@@ -32,10 +17,5 @@ public record GetPlaceRankResponse(int ranking, List<String> nickname, int shari
                 .sorted(Comparator.comparing(PlaceRankWithRankingProjection::getModifiedAt))
                 .map(PlaceRankWithRankingProjection::getNickname)
                 .toList();
-    }
-
-    private static boolean containsUserNickname(List<PlaceRankWithRankingProjection> placeRanks, User user) {
-        return placeRanks.stream()
-                .anyMatch(rank -> rank.getNickname().equals(user.getNickname()));
     }
 }

--- a/src/main/java/ku_rum/backend/domain/rank/application/response/GetPlaceRankResponse.java
+++ b/src/main/java/ku_rum/backend/domain/rank/application/response/GetPlaceRankResponse.java
@@ -1,11 +1,17 @@
 package ku_rum.backend.domain.rank.application.response;
 
 import ku_rum.backend.domain.rank.dto.PlaceRankWithRankingProjection;
+import ku_rum.backend.domain.user.domain.User;
 
 public record GetPlaceRankResponse(int ranking, String nickname, int sharingCount) {
 
     public static GetPlaceRankResponse from(PlaceRankWithRankingProjection placeRanks) {
 
         return new GetPlaceRankResponse(placeRanks.getRanking(), placeRanks.getNickname(), placeRanks.getCount());
+    }
+
+    public static GetPlaceRankResponse emptyFrom(User user) {
+        return new GetPlaceRankResponse(-1, user.getNickname(), 0);
+
     }
 }

--- a/src/main/java/ku_rum/backend/domain/rank/application/response/GetPlaceRankResponse.java
+++ b/src/main/java/ku_rum/backend/domain/rank/application/response/GetPlaceRankResponse.java
@@ -5,13 +5,16 @@ import ku_rum.backend.domain.user.domain.User;
 
 public record GetPlaceRankResponse(int ranking, String nickname, int sharingCount) {
 
+    private static final int EXCEPTION_RANKING = -1;
+    private static final int EXCEPTION_COUNT_RANKING = 0;
+
     public static GetPlaceRankResponse from(PlaceRankWithRankingProjection placeRanks) {
 
         return new GetPlaceRankResponse(placeRanks.getRanking(), placeRanks.getNickname(), placeRanks.getCount());
     }
 
     public static GetPlaceRankResponse emptyFrom(User user) {
-        return new GetPlaceRankResponse(-1, user.getNickname(), 0);
+        return new GetPlaceRankResponse(EXCEPTION_RANKING, user.getNickname(), EXCEPTION_COUNT_RANKING);
 
     }
 }

--- a/src/main/java/ku_rum/backend/domain/rank/application/response/GetPlaceRankResponse.java
+++ b/src/main/java/ku_rum/backend/domain/rank/application/response/GetPlaceRankResponse.java
@@ -1,21 +1,11 @@
 package ku_rum.backend.domain.rank.application.response;
 
-import java.util.Comparator;
-import java.util.List;
 import ku_rum.backend.domain.rank.dto.PlaceRankWithRankingProjection;
-import ku_rum.backend.domain.user.domain.User;
 
 public record GetPlaceRankResponse(int ranking, String nickname, int sharingCount) {
 
-    public static GetPlaceRankResponse from(PlaceRankWithRankingProjection placeRanks, User user) {
+    public static GetPlaceRankResponse from(PlaceRankWithRankingProjection placeRanks) {
 
         return new GetPlaceRankResponse(placeRanks.getRanking(), placeRanks.getNickname(), placeRanks.getCount());
-    }
-
-    private static List<String> extractSortedNicknames(List<PlaceRankWithRankingProjection> placeRanks) {
-        return placeRanks.stream()
-                .sorted(Comparator.comparing(PlaceRankWithRankingProjection::getModifiedAt))
-                .map(PlaceRankWithRankingProjection::getNickname)
-                .toList();
     }
 }

--- a/src/main/java/ku_rum/backend/domain/rank/domain/repository/PlaceRankRepository.java
+++ b/src/main/java/ku_rum/backend/domain/rank/domain/repository/PlaceRankRepository.java
@@ -93,4 +93,32 @@ public interface PlaceRankRepository extends JpaRepository<PlaceRank, Long> {
     List<PlaceRankWithRankingProjection> findRankByRange(@Param("placeId") Long placeId,
                                                          @Param("startRank") int startRank,
                                                          @Param("endRank") int endRank);
+
+    @Query(value = """
+                SELECT 
+                    ranked.rank_id          AS rankId,
+                    ranked.count            AS count,
+                    u.nickname              AS nickname,
+                    ranked.place_place_id   AS placePlaceId,
+                    ranked.created_at       AS createdAt,
+                    ranked.modified_at      AS modifiedAt,
+                    ranked.ranking          AS ranking
+                FROM (
+                    SELECT 
+                        pr.*, 
+                        DENSE_RANK() OVER (ORDER BY pr.count DESC) AS ranking
+                    FROM place_rank pr
+                    WHERE place_place_id =:placeId
+                ) ranked
+                JOIN users u
+                    ON u.id = ranked.user_id
+                WHERE (ranked.ranking > :lastRank)
+                   OR (ranked.ranking = :lastRank AND ranked.rank_id > :lastRankId)
+                ORDER BY ranked.ranking, ranked.rank_id
+                LIMIT :limit
+            """, nativeQuery = true)
+    List<PlaceRankWithRankingProjection> findRankByRange(@Param("placeId") Long placeId,
+                                                         @Param("lastRank") int lastRank,
+                                                         @Param("lastRankId") Long lastRankId,
+                                                         @Param("limit") int limit);
 }

--- a/src/main/java/ku_rum/backend/domain/rank/domain/repository/PlaceRankRepository.java
+++ b/src/main/java/ku_rum/backend/domain/rank/domain/repository/PlaceRankRepository.java
@@ -121,4 +121,29 @@ public interface PlaceRankRepository extends JpaRepository<PlaceRank, Long> {
                                                          @Param("lastRank") int lastRank,
                                                          @Param("lastRankId") Long lastRankId,
                                                          @Param("limit") int limit);
+
+    @Query(value = """
+                SELECT 
+                    ranked.rank_id          AS rankId,
+                    ranked.count            AS count,
+                    u.nickname              AS nickname,
+                    ranked.place_place_id   AS placePlaceId,
+                    ranked.created_at       AS createdAt,
+                    ranked.modified_at      AS modifiedAt,
+                    ranked.ranking          AS ranking
+                FROM (
+                    SELECT 
+                        pr.*, 
+                        DENSE_RANK() OVER (ORDER BY pr.count DESC) AS ranking
+                    FROM place_rank pr
+                    WHERE place_place_id = :placeId
+                ) ranked
+                JOIN users u
+                    ON u.id = ranked.user_id
+                WHERE ranked.user_id = :userId
+                   AND ranked.place_place_id = :placeId
+                LIMIT 1
+            """, nativeQuery = true)
+    Optional<PlaceRankWithRankingProjection> findRankByPlaceAndUser(@Param("placeId") Long placeId,
+                                                                    @Param("userId") Long userId);
 }

--- a/src/main/java/ku_rum/backend/domain/rank/dto/PlaceRankingLastKnownCursor.java
+++ b/src/main/java/ku_rum/backend/domain/rank/dto/PlaceRankingLastKnownCursor.java
@@ -1,5 +1,9 @@
 package ku_rum.backend.domain.rank.dto;
 
+import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.INVALID_LAST_KNOWN;
+
+import ku_rum.backend.global.exception.global.GlobalException;
+
 public record PlaceRankingLastKnownCursor(int lastRank, Long lastRankId) {
 
     private static final String DELIMITER = "_"; // 구분자, 예: "10_12345"
@@ -11,7 +15,7 @@ public record PlaceRankingLastKnownCursor(int lastRank, Long lastRankId) {
 
         String[] parts = lastKnown.split(DELIMITER);
         if (parts.length != 2) {
-            throw new IllegalArgumentException("잘못된 lastKnown" + lastKnown);
+            throw new GlobalException(INVALID_LAST_KNOWN);
         }
 
         try {
@@ -19,7 +23,7 @@ public record PlaceRankingLastKnownCursor(int lastRank, Long lastRankId) {
             Long lastRankId = Long.parseLong(parts[1]);
             return new PlaceRankingLastKnownCursor(lastRank, lastRankId);
         } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("잘못된 lastKnown" + lastKnown);
+            throw new GlobalException(INVALID_LAST_KNOWN);
         }
     }
 

--- a/src/main/java/ku_rum/backend/domain/rank/dto/PlaceRankingLastKnownCursor.java
+++ b/src/main/java/ku_rum/backend/domain/rank/dto/PlaceRankingLastKnownCursor.java
@@ -1,0 +1,33 @@
+package ku_rum.backend.domain.rank.dto;
+
+public record PlaceRankingLastKnownCursor(int lastRank, Long lastRankId) {
+
+    private static final String DELIMITER = "_"; // 구분자, 예: "10_12345"
+
+    public static PlaceRankingLastKnownCursor from(String lastKnown) {
+        if (lastKnown == null || lastKnown.isBlank()) {
+            return new PlaceRankingLastKnownCursor(0, 0);
+        }
+
+        String[] parts = lastKnown.split(DELIMITER);
+        if (parts.length != 2) {
+            throw new IllegalArgumentException("잘못된 lastKnown" + lastKnown);
+        }
+
+        try {
+            int lastRank = Integer.parseInt(parts[0]);
+            Long lastRankId = Long.parseLong(parts[1]);
+            return new PlaceRankingLastKnownCursor(lastRank, lastRankId);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("잘못된 lastKnown" + lastKnown);
+        }
+    }
+
+    public static PlaceRankingLastKnownCursor of(int lastRank, Long lastRankId) {
+        return new PlaceRankingLastKnownCursor(lastRank, lastRankId);
+    }
+
+    public String toCursorString() {
+        return lastRank + DELIMITER + lastRankId;
+    }
+}

--- a/src/main/java/ku_rum/backend/domain/rank/dto/PlaceRankingLastKnownCursor.java
+++ b/src/main/java/ku_rum/backend/domain/rank/dto/PlaceRankingLastKnownCursor.java
@@ -6,7 +6,7 @@ public record PlaceRankingLastKnownCursor(int lastRank, Long lastRankId) {
 
     public static PlaceRankingLastKnownCursor from(String lastKnown) {
         if (lastKnown == null || lastKnown.isBlank()) {
-            return new PlaceRankingLastKnownCursor(0, 0);
+            return new PlaceRankingLastKnownCursor(0, 0L);
         }
 
         String[] parts = lastKnown.split(DELIMITER);

--- a/src/main/java/ku_rum/backend/domain/rank/dto/request/PlaceRankPaginationRequest.java
+++ b/src/main/java/ku_rum/backend/domain/rank/dto/request/PlaceRankPaginationRequest.java
@@ -1,0 +1,4 @@
+package ku_rum.backend.domain.rank.dto.request;
+
+public record PlaceRankPaginationRequest(String lastKnown, int limit) {
+}

--- a/src/main/java/ku_rum/backend/domain/rank/dto/request/PlaceRankPaginationRequest.java
+++ b/src/main/java/ku_rum/backend/domain/rank/dto/request/PlaceRankPaginationRequest.java
@@ -1,4 +1,9 @@
 package ku_rum.backend.domain.rank.dto.request;
 
-public record PlaceRankPaginationRequest(String lastKnown, int limit) {
+import jakarta.validation.constraints.Min;
+
+public record PlaceRankPaginationRequest(String lastKnown,
+                                         @Min(value = 1, message = "limit은 1 이상이어야 합니다.")
+                                         int limit) {
+
 }

--- a/src/main/java/ku_rum/backend/domain/rank/presentation/RankController.java
+++ b/src/main/java/ku_rum/backend/domain/rank/presentation/RankController.java
@@ -10,9 +10,9 @@ import ku_rum.backend.global.support.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -37,11 +37,10 @@ public class RankController {
 
     @GetMapping("/{placeId}/ranks")
     public BaseResponse<GetPlaceRankPaginationResponse> getPlaceRank(
-            @AuthenticationPrincipal final CustomUserDetails userDetails,
             @PathVariable("placeId") final Long placeId,
-            @RequestParam PlaceRankPaginationRequest request) {
-        rankService.getPlaceRanks(userDetails, placeId, request);
-        return BaseResponse.ok(rankService.getPlaceRanks(userDetails, placeId, request));
+            @ModelAttribute PlaceRankPaginationRequest request) {
+        rankService.getPlaceRanks(placeId, request);
+        return BaseResponse.ok(rankService.getPlaceRanks(placeId, request));
     }
 
     @GetMapping("/{placeId}/ranks/me")

--- a/src/main/java/ku_rum/backend/domain/rank/presentation/RankController.java
+++ b/src/main/java/ku_rum/backend/domain/rank/presentation/RankController.java
@@ -27,14 +27,14 @@ public class RankController {
         return BaseResponse.ok(rankService.getPlaceUserRank(userDetails));
     }
 
-    @GetMapping("/users/ranks/{friendId}")
+    @GetMapping("/users/{friendId}/ranks")
     public BaseResponse<List<GetPlaceUserRankResponse>> getPlaceFriendRank(
             @AuthenticationPrincipal final CustomUserDetails userDetails,
             @PathVariable("friendId") final Long friendId) {
         return BaseResponse.ok(rankService.getPlaceFriendRank(userDetails, friendId));
     }
 
-    @GetMapping("/ranks/{placeId}")
+    @GetMapping("/{placeId}/ranks")
     public BaseResponse<List<GetPlaceRankResponse>> getPlaceRank(
             @AuthenticationPrincipal final CustomUserDetails userDetails,
             @PathVariable("placeId") final Long placeId,
@@ -42,5 +42,4 @@ public class RankController {
             @RequestParam("endRank") final int endRank) {
         return BaseResponse.ok(rankService.getPlaceRanks(userDetails, placeId, startRank, endRank));
     }
-
 }

--- a/src/main/java/ku_rum/backend/domain/rank/presentation/RankController.java
+++ b/src/main/java/ku_rum/backend/domain/rank/presentation/RankController.java
@@ -1,5 +1,6 @@
 package ku_rum.backend.domain.rank.presentation;
 
+import jakarta.validation.Valid;
 import java.util.List;
 import ku_rum.backend.domain.rank.application.RankService;
 import ku_rum.backend.domain.rank.application.response.GetPlaceRankPaginationResponse;
@@ -39,8 +40,7 @@ public class RankController {
     @GetMapping("/{placeId}/ranks")
     public BaseResponse<GetPlaceRankPaginationResponse> getPlaceRank(
             @PathVariable("placeId") final Long placeId,
-            @ModelAttribute PlaceRankPaginationRequest request) {
-        rankService.getPlaceRanks(placeId, request);
+            @Valid @ModelAttribute PlaceRankPaginationRequest request) {
         return BaseResponse.ok(rankService.getPlaceRanks(placeId, request));
     }
 
@@ -52,7 +52,7 @@ public class RankController {
         return BaseResponse.ok(response);
     }
 
-    @GetMapping("{placeId}/top")
+    @GetMapping("/{placeId}/top")
     public BaseResponse<List<GetPlaceRankResponse>> getPlaceTopRank(
             @PathVariable("placeId") final Long placeId) {
         List<GetPlaceRankResponse> response = rankService.getPlaceTopRank(placeId);

--- a/src/main/java/ku_rum/backend/domain/rank/presentation/RankController.java
+++ b/src/main/java/ku_rum/backend/domain/rank/presentation/RankController.java
@@ -3,6 +3,7 @@ package ku_rum.backend.domain.rank.presentation;
 import java.util.List;
 import ku_rum.backend.domain.rank.application.RankService;
 import ku_rum.backend.domain.rank.application.response.GetPlaceRankPaginationResponse;
+import ku_rum.backend.domain.rank.application.response.GetPlaceRankResponse;
 import ku_rum.backend.domain.rank.application.response.GetPlaceUserRankResponse;
 import ku_rum.backend.domain.rank.dto.request.PlaceRankPaginationRequest;
 import ku_rum.backend.global.security.CustomUserDetails;
@@ -44,9 +45,17 @@ public class RankController {
     }
 
     @GetMapping("/{placeId}/ranks/me")
-    public BaseResponse<List<GetPlaceUserRankResponse>> getPlaceMyRank(
+    public BaseResponse<GetPlaceRankResponse> getPlaceMyRank(
             @AuthenticationPrincipal final CustomUserDetails userDetails,
             @PathVariable("placeId") final Long placeId) {
-        return BaseResponse.ok();
+        GetPlaceRankResponse response = rankService.getUserPlaceRank(userDetails.getUserId(), placeId);
+        return BaseResponse.ok(response);
+    }
+
+    @GetMapping("{placeId}/top")
+    public BaseResponse<List<GetPlaceRankResponse>> getPlaceTopRank(
+            @PathVariable("placeId") final Long placeId) {
+        List<GetPlaceRankResponse> response = rankService.getPlaceTopRank(placeId);
+        return BaseResponse.ok(response);
     }
 }

--- a/src/main/java/ku_rum/backend/domain/rank/presentation/RankController.java
+++ b/src/main/java/ku_rum/backend/domain/rank/presentation/RankController.java
@@ -2,8 +2,9 @@ package ku_rum.backend.domain.rank.presentation;
 
 import java.util.List;
 import ku_rum.backend.domain.rank.application.RankService;
-import ku_rum.backend.domain.rank.application.response.GetPlaceRankResponse;
+import ku_rum.backend.domain.rank.application.response.GetPlaceRankPaginationResponse;
 import ku_rum.backend.domain.rank.application.response.GetPlaceUserRankResponse;
+import ku_rum.backend.domain.rank.dto.request.PlaceRankPaginationRequest;
 import ku_rum.backend.global.security.CustomUserDetails;
 import ku_rum.backend.global.support.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
@@ -35,11 +36,11 @@ public class RankController {
     }
 
     @GetMapping("/{placeId}/ranks")
-    public BaseResponse<List<GetPlaceRankResponse>> getPlaceRank(
+    public BaseResponse<GetPlaceRankPaginationResponse> getPlaceRank(
             @AuthenticationPrincipal final CustomUserDetails userDetails,
             @PathVariable("placeId") final Long placeId,
-            @RequestParam("startRank") final int startRank,
-            @RequestParam("endRank") final int endRank) {
-        return BaseResponse.ok(rankService.getPlaceRanks(userDetails, placeId, startRank, endRank));
+            @RequestParam PlaceRankPaginationRequest request){
+        rankService.getPlaceRanks(userDetails.getUserId(),placeId,request)
+        return BaseResponse.ok(rankService.getPlaceRanks(userDetails, placeId, placeRankPaginationRequest));
     }
 }

--- a/src/main/java/ku_rum/backend/domain/rank/presentation/RankController.java
+++ b/src/main/java/ku_rum/backend/domain/rank/presentation/RankController.java
@@ -39,8 +39,15 @@ public class RankController {
     public BaseResponse<GetPlaceRankPaginationResponse> getPlaceRank(
             @AuthenticationPrincipal final CustomUserDetails userDetails,
             @PathVariable("placeId") final Long placeId,
-            @RequestParam PlaceRankPaginationRequest request){
-        rankService.getPlaceRanks(userDetails.getUserId(),placeId,request)
-        return BaseResponse.ok(rankService.getPlaceRanks(userDetails, placeId, placeRankPaginationRequest));
+            @RequestParam PlaceRankPaginationRequest request) {
+        rankService.getPlaceRanks(userDetails, placeId, request);
+        return BaseResponse.ok(rankService.getPlaceRanks(userDetails, placeId, request));
+    }
+
+    @GetMapping("/{placeId}/ranks/me")
+    public BaseResponse<List<GetPlaceUserRankResponse>> getPlaceMyRank(
+            @AuthenticationPrincipal final CustomUserDetails userDetails,
+            @PathVariable("placeId") final Long placeId) {
+        return BaseResponse.ok();
     }
 }

--- a/src/main/java/ku_rum/backend/global/support/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/ku_rum/backend/global/support/status/BaseExceptionResponseStatus.java
@@ -130,6 +130,7 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     DUPLICATE_BOOKMARK(1300, HttpStatus.BAD_REQUEST, "이미 북마크 공지사항입니다."),
     BOOKMARK_NOT_FOUND(1301, HttpStatus.NOT_FOUND, "해당되는 북마크가 없습니다."),
     UNAUTHORIZED_BOOKMARK(1302, HttpStatus.UNAUTHORIZED, "권한이 없는 북마크 입니다."),
+    INVALID_LAST_KNOWN(1303, HttpStatus.BAD_REQUEST, "잘못된 lastknown 입니다"),
     ;
 
     private final int code;

--- a/src/test/java/ku_rum/backend/domain/rank/presentation/RankControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/rank/presentation/RankControllerTest.java
@@ -17,7 +17,6 @@ import ku_rum.backend.domain.rank.application.RankService;
 import ku_rum.backend.domain.rank.application.response.GetPlaceRankPaginationResponse;
 import ku_rum.backend.domain.rank.application.response.GetPlaceRankResponse;
 import ku_rum.backend.domain.rank.application.response.GetPlaceUserRankResponse;
-import ku_rum.backend.domain.rank.dto.request.PlaceRankPaginationRequest;
 import ku_rum.backend.global.domain.repository.ApiLogRepository;
 import ku_rum.backend.global.security.CustomUserDetails;
 import ku_rum.backend.global.security.JwtTokenAuthenticationFilter;
@@ -26,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.request.RequestDocumentation;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -112,7 +110,6 @@ public class RankControllerTest extends RestDocsTestSupport {
 
     @DisplayName("특정 장소의 랭킹을 구간별로 조회한다")
     @Test
-    @WithMockUser(username = "testUser", roles = {"USER"})
     void getPlaceRank() throws Exception {
         // given
         Long placeId = 75L;
@@ -126,42 +123,39 @@ public class RankControllerTest extends RestDocsTestSupport {
         );
         GetPlaceRankPaginationResponse response = GetPlaceRankPaginationResponse.of(getPlaceRankResponses, false,
                 "4_2");
-        PlaceRankPaginationRequest placeRankPaginationRequest = new PlaceRankPaginationRequest(null, 3);
-        given(rankService.getPlaceRanks(any(), eq(placeId), eq(placeRankPaginationRequest)))
+        given(rankService.getPlaceRanks(eq(placeId), any()))
                 .willReturn(response);
 
         // when & then
-        mockMvc.perform(get("/api/v1/places/ranks/{placeId}", placeId)
-                        .param("startRank", String.valueOf(startRank))
-                        .param("endRank", String.valueOf(endRank))
-                        .header("Authorization",
-                                "Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyUEsiOjEsInJvbGVzIjoiUk9MRV9VU0VSIiwiaWF0IjoxNzQwMjQyNjQxLCJleHAiOjE3NDAyNDQ0NDF9.kLSMBLWdvIvrBpㄴGJdOigSKjxMIab0cV06xFjSpwrq70"))
+        mockMvc.perform(get("/api/v1/places/{placeId}/ranks", placeId)
+                        .param("lastKnown", "")
+                        .param("limit", "3"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(resource(
                         ResourceSnippetParameters.builder()
                                 .tag("랭킹 관련 API")
                                 .description("특정 장소의 랭킹을 구간별로 조회합니다.")
-                                .requestHeaders(
-                                        headerWithName("Authorization").description("발급받은 엑세스 토큰")
-                                )
                                 .pathParameters(
                                         RequestDocumentation.parameterWithName("placeId").description("조회할 장소의 ID")
                                 )
                                 .queryParameters(
-                                        RequestDocumentation.parameterWithName("startRank").description("조회 시작 랭크"),
-                                        RequestDocumentation.parameterWithName("endRank").description("조회 종료 랭크")
+                                        RequestDocumentation.parameterWithName("lastKnown").description("가장 최근 커서"),
+                                        RequestDocumentation.parameterWithName("limit").description("갯수")
                                 )
                                 .responseFields(
                                         fieldWithPath("code").description("응답 코드"),
                                         fieldWithPath("status").description("응답 상태"),
                                         fieldWithPath("message").description("응답 메시지"),
-                                        fieldWithPath("data[].ranking").description("순위"),
-                                        fieldWithPath("data[].nickname").description("닉네임 목록"),
-                                        fieldWithPath("data[].sharingCount").description("공유 횟수"),
-                                        fieldWithPath("data[].isSelf").description("본인 여부")
+                                        fieldWithPath("data.ranks[].ranking").description("순위"),
+                                        fieldWithPath("data.ranks[].nickname").description("닉네임 목록"),
+                                        fieldWithPath("data.ranks[].sharingCount").description("공유 횟수"),
+                                        fieldWithPath("data.hasNext").description("마지막 여부"),
+                                        fieldWithPath("data.nextCursor").description("nextCursor")
                                 )
                                 .build()
                 )));
     }
+
+
 }

--- a/src/test/java/ku_rum/backend/domain/rank/presentation/RankControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/rank/presentation/RankControllerTest.java
@@ -211,6 +211,7 @@ public class RankControllerTest extends RestDocsTestSupport {
 
         // when & then
         mockMvc.perform(get("/api/v1/places/{placeId}/ranks/me", placeId)
+                        .header("Authorization", "Bearer test-access-token")
                         .principal(new UsernamePasswordAuthenticationToken(
                                 userDetails,
                                 userDetails.getPassword(),
@@ -273,4 +274,6 @@ public class RankControllerTest extends RestDocsTestSupport {
                                 .build()
                 )));
     }
+
+
 }

--- a/src/test/java/ku_rum/backend/domain/rank/presentation/RankControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/rank/presentation/RankControllerTest.java
@@ -82,22 +82,36 @@ public class RankControllerTest extends RestDocsTestSupport {
 
     @DisplayName("친구 장소 공유 순위를 확인한다")
     @Test
+    @WithMockUser(username = "testUser", roles = {"USER"})
     void getPlaceFriendRank() throws Exception {
-        //given
-        String placeName = "상허기념도서관";
+        // given
         Long friendId = 2L;
+        String placeName = "상허기념도서관";
         int count = 5;
-        GetPlaceUserRankResponse getPlaceUserRankResponse = new GetPlaceUserRankResponse(List.of(placeName), count);
-        List<GetPlaceUserRankResponse> response = List.of(getPlaceUserRankResponse);
+
+        CustomUserDetails userDetails = CustomUserDetails.of(
+                1L,
+                "testUser",
+                AuthorityUtils.createAuthorityList("ROLE_USER"),
+                "password",
+                false
+        );
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(
+                userDetails,
+                null,
+                userDetails.getAuthorities()
+        ));
+        SecurityContextHolder.setContext(context);
+        GetPlaceUserRankResponse friendRankResponse = new GetPlaceUserRankResponse(List.of(placeName), count);
+        List<GetPlaceUserRankResponse> response = List.of(friendRankResponse);
 
         given(rankService.getPlaceFriendRank(any(CustomUserDetails.class), eq(friendId)))
                 .willReturn(response);
 
-        //when
-        mockMvc.perform(get("/api/v1/places/users/ranks/{friendId}", friendId)
-                        .header("Authorization",
-                                "Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyUEsiOjEsInJvbGVzIjoiUk9MRV9VU0VSIiwiaWF0IjoxNzQwMjQyNjQxLCJleHAiOjE3NDAyNDQ0NDF9.kLSMBLWdvIvrBpㄴGJdOigSKjxMIab0cV06xFjSpwrq70"))
-                //then
+        // when & then
+        mockMvc.perform(get("/api/v1/places/users/{friendId}/ranks", friendId)
+                        .header("Authorization", "Bearer test-access-token"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(resource(
@@ -105,13 +119,20 @@ public class RankControllerTest extends RestDocsTestSupport {
                                 .tag("지도 관련 API")
                                 .description("지도 장소 친구 랭킹 조회")
                                 .requestHeaders(
-                                        headerWithName("Authorization").description("발급 받은 엑세스 토큰입니다.")
+                                        headerWithName("Authorization").description("발급 받은 액세스 토큰")
                                 )
                                 .pathParameters(
-                                        RequestDocumentation.parameterWithName("friendId").description("친구id")
+                                        RequestDocumentation.parameterWithName("friendId").description("조회할 친구 ID")
                                 )
-                                .build())));
-
+                                .responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("응답 상태"),
+                                        fieldWithPath("message").description("응답 메시지"),
+                                        fieldWithPath("data[].name").description("친구가 공유한 장소 목록"),
+                                        fieldWithPath("data[].sharingCount").description("친구의 공유 횟수")
+                                )
+                                .build()
+                )));
     }
 
     @DisplayName("특정 장소의 랭킹을 구간별로 조회한다")
@@ -144,9 +165,6 @@ public class RankControllerTest extends RestDocsTestSupport {
                                 .pathParameters(
                                         RequestDocumentation.parameterWithName("placeId").description("조회할 장소의 ID")
                                 )
-                                .requestHeaders(
-                                        headerWithName("Authorization").description("발급 받은 엑세스 토큰입니다.")
-                                )
                                 .queryParameters(
                                         RequestDocumentation.parameterWithName("lastKnown").description("가장 최근 커서"),
                                         RequestDocumentation.parameterWithName("limit").description("갯수")
@@ -165,7 +183,7 @@ public class RankControllerTest extends RestDocsTestSupport {
                 )));
     }
 
-    @DisplayName("사용자의 특정 장소 랭킹을 조회한다")
+    @DisplayName("사용자의 특정 장소 내랭킹을 조회한다")
     @Test
     @WithMockUser(username = "testUser", roles = {"USER"})
     void getPlaceMyRank() throws Exception {
@@ -214,6 +232,43 @@ public class RankControllerTest extends RestDocsTestSupport {
                                         fieldWithPath("data.ranking").description("순위"),
                                         fieldWithPath("data.nickname").description("닉네임"),
                                         fieldWithPath("data.sharingCount").description("공유 횟수")
+                                )
+                                .build()
+                )));
+    }
+
+    @DisplayName("특정 장소의 상위 랭킹을 조회한다")
+    @Test
+    void getPlaceTopRank() throws Exception {
+        // given
+        Long placeId = 75L;
+
+        List<GetPlaceRankResponse> topRanks = List.of(
+                new GetPlaceRankResponse(1, "UserA", 15),
+                new GetPlaceRankResponse(2, "UserB", 12),
+                new GetPlaceRankResponse(3, "UserC", 10)
+        );
+
+        given(rankService.getPlaceTopRank(eq(placeId))).willReturn(topRanks);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/places/{placeId}/top", placeId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("랭킹 관련 API")
+                                .description("특정 장소의 상위 랭킹을 조회합니다.")
+                                .pathParameters(
+                                        parameterWithName("placeId").description("조회할 장소의 ID")
+                                )
+                                .responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("응답 상태"),
+                                        fieldWithPath("message").description("응답 메시지"),
+                                        fieldWithPath("data[].ranking").description("순위"),
+                                        fieldWithPath("data[].nickname").description("닉네임"),
+                                        fieldWithPath("data[].sharingCount").description("공유 횟수")
                                 )
                                 .build()
                 )));

--- a/src/test/java/ku_rum/backend/domain/rank/presentation/RankControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/rank/presentation/RankControllerTest.java
@@ -14,8 +14,10 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import java.util.List;
 import ku_rum.backend.config.RestDocsTestSupport;
 import ku_rum.backend.domain.rank.application.RankService;
+import ku_rum.backend.domain.rank.application.response.GetPlaceRankPaginationResponse;
 import ku_rum.backend.domain.rank.application.response.GetPlaceRankResponse;
 import ku_rum.backend.domain.rank.application.response.GetPlaceUserRankResponse;
+import ku_rum.backend.domain.rank.dto.request.PlaceRankPaginationRequest;
 import ku_rum.backend.global.domain.repository.ApiLogRepository;
 import ku_rum.backend.global.security.CustomUserDetails;
 import ku_rum.backend.global.security.JwtTokenAuthenticationFilter;
@@ -117,13 +119,15 @@ public class RankControllerTest extends RestDocsTestSupport {
         int startRank = 1;
         int endRank = 10;
 
-        List<GetPlaceRankResponse> response = List.of(
-                new GetPlaceRankResponse(2, List.of("테스트8"), 8, false),
-                new GetPlaceRankResponse(3, List.of("테스트7"), 7, false),
-                new GetPlaceRankResponse(4, List.of("테스트6"), 6, false)
+        List<GetPlaceRankResponse> getPlaceRankResponses = List.of(
+                new GetPlaceRankResponse(2, "테스트8", 8),
+                new GetPlaceRankResponse(3, "테스트7", 7),
+                new GetPlaceRankResponse(4, "테스트6", 6)
         );
-
-        given(rankService.getPlaceRanks(any(), eq(placeId), eq(startRank), eq(endRank)))
+        GetPlaceRankPaginationResponse response = GetPlaceRankPaginationResponse.of(getPlaceRankResponses, false,
+                "4_2");
+        PlaceRankPaginationRequest placeRankPaginationRequest = new PlaceRankPaginationRequest(null, 3);
+        given(rankService.getPlaceRanks(any(), eq(placeId), eq(placeRankPaginationRequest)))
                 .willReturn(response);
 
         // when & then

--- a/src/test/java/ku_rum/backend/domain/rank/presentation/RankControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/rank/presentation/RankControllerTest.java
@@ -1,5 +1,6 @@
 package ku_rum.backend.domain.rank.presentation;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -25,6 +26,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.request.RequestDocumentation;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -113,8 +119,6 @@ public class RankControllerTest extends RestDocsTestSupport {
     void getPlaceRank() throws Exception {
         // given
         Long placeId = 75L;
-        int startRank = 1;
-        int endRank = 10;
 
         List<GetPlaceRankResponse> getPlaceRankResponses = List.of(
                 new GetPlaceRankResponse(2, "테스트8", 8),
@@ -130,6 +134,7 @@ public class RankControllerTest extends RestDocsTestSupport {
         mockMvc.perform(get("/api/v1/places/{placeId}/ranks", placeId)
                         .param("lastKnown", "")
                         .param("limit", "3"))
+
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(resource(
@@ -138,6 +143,9 @@ public class RankControllerTest extends RestDocsTestSupport {
                                 .description("특정 장소의 랭킹을 구간별로 조회합니다.")
                                 .pathParameters(
                                         RequestDocumentation.parameterWithName("placeId").description("조회할 장소의 ID")
+                                )
+                                .requestHeaders(
+                                        headerWithName("Authorization").description("발급 받은 엑세스 토큰입니다.")
                                 )
                                 .queryParameters(
                                         RequestDocumentation.parameterWithName("lastKnown").description("가장 최근 커서"),
@@ -157,5 +165,57 @@ public class RankControllerTest extends RestDocsTestSupport {
                 )));
     }
 
+    @DisplayName("사용자의 특정 장소 랭킹을 조회한다")
+    @Test
+    @WithMockUser(username = "testUser", roles = {"USER"})
+    void getPlaceMyRank() throws Exception {
+        // given
+        Long placeId = 75L;
 
+        CustomUserDetails userDetails = CustomUserDetails.of(
+                1L,
+                "testUser",
+                AuthorityUtils.createAuthorityList("ROLE_USER"),
+                "password",
+                false
+        );
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(
+                userDetails,
+                null,
+                userDetails.getAuthorities()
+        ));
+        SecurityContextHolder.setContext(context);
+
+        GetPlaceRankResponse myRankResponse = new GetPlaceRankResponse(5, "testUser", 10);
+        given(rankService.getUserPlaceRank(eq(userDetails.getUserId()), eq(placeId)))
+                .willReturn(myRankResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/places/{placeId}/ranks/me", placeId)
+                        .principal(new UsernamePasswordAuthenticationToken(
+                                userDetails,
+                                userDetails.getPassword(),
+                                userDetails.getAuthorities()
+                        )))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("랭킹 관련 API")
+                                .description("사용자의 특정 장소 랭킹을 조회합니다.")
+                                .pathParameters(
+                                        parameterWithName("placeId").description("조회할 장소의 ID")
+                                )
+                                .responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("응답 상태"),
+                                        fieldWithPath("message").description("응답 메시지"),
+                                        fieldWithPath("data.ranking").description("순위"),
+                                        fieldWithPath("data.nickname").description("닉네임"),
+                                        fieldWithPath("data.sharingCount").description("공유 횟수")
+                                )
+                                .build()
+                )));
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closes #323 

## 📝작업 내용
- [x] 랭킹 페이지네이션 추가
- [x] 본인 랭킹 API 추가
- [x] 상위 3등 랭킹 API 추가

## 작업 상세 내용
- 3개의 API를 추가했습니다
  - 기존에 API관점에서 문제가 많이 해결되서 기쁘네요
  - 페이지네이션은 커서기반입니다

## 💬리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 장소별 랭킹에 커서 기반 페이지네이션 도입 (lastKnown, limit, hasNext, nextCursor 제공)
  * 현재 사용자 장소별 랭킹 조회 추가 (GET /{placeId}/ranks/me)
  * 장소별 상위 랭킹 조회 추가 (GET /{placeId}/top)

* **Refactor**
  * 랭킹 조회 경로 및 파라미터 정비(/{placeId}/ranks, 모델 바인딩 적용)
  * 랭킹 응답 포맷 단순화(닉네임 단일값, 공유수 중심)

* **Tests**
  * 페이지네이션·사용자·상위 랭킹 흐름 관련 테스트 보강 및 REST Docs 업데이트

* **Bug Fix / Validation**
  * lastKnown 포맷 검증 및 관련 오류 상태 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->