### PR TITLE
[Feat] 인기 공지 API 추가

### DIFF
--- a/src/main/java/ku_rum/backend/domain/notice/application/NoticeService.java
+++ b/src/main/java/ku_rum/backend/domain/notice/application/NoticeService.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class NoticeService {
 
-    private final int POPULAR_NOTICE_COUNT = 3;
+    private static final int POPULAR_NOTICE_COUNT = 3;
     private final NoticeRepository noticeRepository;
     private final NoticeDetailRepository noticeDetailRepository;
 

--- a/src/main/java/ku_rum/backend/domain/notice/application/NoticeService.java
+++ b/src/main/java/ku_rum/backend/domain/notice/application/NoticeService.java
@@ -3,8 +3,6 @@ package ku_rum.backend.domain.notice.application;
 import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.NO_SUCH_NOTICE;
 import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.NO_SUCH_NOTICE_DETAIL;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.List;
 import ku_rum.backend.domain.notice.domain.Notice;
 import ku_rum.backend.domain.notice.domain.NoticeDetail;

--- a/src/main/java/ku_rum/backend/domain/notice/application/NoticeService.java
+++ b/src/main/java/ku_rum/backend/domain/notice/application/NoticeService.java
@@ -5,6 +5,7 @@ import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.N
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
 import ku_rum.backend.domain.notice.domain.Notice;
 import ku_rum.backend.domain.notice.domain.NoticeDetail;
 import ku_rum.backend.domain.notice.domain.PublishStatus;
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class NoticeService {
 
+    private final int POPULAR_NOTICE_COUNT = 3;
     private final NoticeRepository noticeRepository;
     private final NoticeDetailRepository noticeDetailRepository;
 
@@ -42,6 +44,14 @@ public class NoticeService {
 
     public Notice findNoticeByNoticeId(Long noticeId) {
         return noticeRepository.findById(noticeId).orElseThrow(() -> new GlobalException(NO_SUCH_NOTICE));
+    }
+
+    public List<NoticeResponse> findPopularNotice() {
+        Long limit = Long.valueOf(POPULAR_NOTICE_COUNT);
+        return noticeRepository.findTopByBookmark(limit)
+                .stream()
+                .map(NoticeResponse::from)
+                .toList();
     }
 }
 

--- a/src/main/java/ku_rum/backend/domain/notice/domain/repository/NoticeRepository.java
+++ b/src/main/java/ku_rum/backend/domain/notice/domain/repository/NoticeRepository.java
@@ -1,13 +1,26 @@
 package ku_rum.backend.domain.notice.domain.repository;
 
+import java.util.List;
 import ku_rum.backend.domain.notice.domain.Notice;
 import ku_rum.backend.domain.notice.domain.PublishStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
     Page<Notice> findByCategoryId(Long categoryId, Pageable pageable);
 
     Page<Notice> findByCategoryIdAndPublishStatus(Long categoryId, PublishStatus publishStatus, Pageable pageable);
+
+    @Query(value = """
+            SELECT n.*
+            FROM notice_bookmark nb
+            JOIN notice n ON nb.notice_id = n.id
+            GROUP BY n.id
+            ORDER BY COUNT(nb.id) DESC
+            LIMIT :limit
+            """, nativeQuery = true)
+    List<Notice> findTopByBookmark(@Param("limit") Long limit);
 }

--- a/src/main/java/ku_rum/backend/domain/notice/domain/repository/NoticeRepository.java
+++ b/src/main/java/ku_rum/backend/domain/notice/domain/repository/NoticeRepository.java
@@ -16,8 +16,9 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     @Query(value = """
             SELECT n.*
-            FROM notice_bookmark nb
-            JOIN notice n ON nb.notice_id = n.id
+            FROM notice n
+            LEFT JOIN notice_bookmark nb ON nb.notice_id = n.id
+            WHERE n.publish_status = 'SUCCESS_CRAWLING'
             GROUP BY n.id
             ORDER BY COUNT(nb.id) DESC
             LIMIT :limit

--- a/src/main/java/ku_rum/backend/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/ku_rum/backend/domain/notice/presentation/NoticeController.java
@@ -1,8 +1,10 @@
 package ku_rum.backend.domain.notice.presentation;
 
+import java.util.List;
 import ku_rum.backend.domain.notice.application.NoticeService;
 import ku_rum.backend.domain.notice.dto.response.NoticeDetailResponse;
 import ku_rum.backend.domain.notice.dto.response.NoticeResponse;
+import ku_rum.backend.global.support.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,5 +37,11 @@ public class NoticeController {
         return ResponseEntity.ok()
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML_VALUE) // HTML로 전달
                 .body(response.content());
+    }
+
+    @GetMapping("/popular")
+    public BaseResponse<List<NoticeResponse>> getPopularCategory() {
+        List<NoticeResponse> response = noticeService.findPopularNotice();
+        return BaseResponse.ok(response);
     }
 }

--- a/src/main/java/ku_rum/backend/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/ku_rum/backend/domain/notice/presentation/NoticeController.java
@@ -40,7 +40,7 @@ public class NoticeController {
     }
 
     @GetMapping("/popular")
-    public BaseResponse<List<NoticeResponse>> getPopularCategory() {
+    public BaseResponse<List<NoticeResponse>> getPopularNotices() {
         List<NoticeResponse> response = noticeService.findPopularNotice();
         return BaseResponse.ok(response);
     }

--- a/src/test/java/ku_rum/backend/domain/notice/presentation/NoticeControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/notice/presentation/NoticeControllerTest.java
@@ -127,4 +127,50 @@ public class NoticeControllerTest extends RestDocsTestSupport {
                         )
                 ));
     }
+
+    @DisplayName("인기 공지사항 목록을 조회한다.")
+    @Test
+    void getPopularNotices() throws Exception {
+        // given
+        List<NoticeResponse> fakeResponse = List.of(
+                new NoticeResponse(1L, 1L, "link1", "공지 제목 1", "내용 1", "date1", "작성장1", "설명1"),
+                new NoticeResponse(2L, 2L, "link2", "공지 제목 2", "내용 2", "date2", "작성장2", "설명2"),
+                new NoticeResponse(3L, 3L, "link3", "공지 제목 3", "내용 3", "date3", "작성장3", "설명3")
+        );
+
+        given(noticeService.findPopularNotice())
+                .willReturn(fakeResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/notices/popular"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value("OK")) // BaseResponse 기준
+                .andExpect(jsonPath("$.data[0].id").value(1))
+                .andExpect(jsonPath("$.data[0].title").value("공지 제목 1"))
+                .andExpect(jsonPath("$.data[1].id").value(2))
+                .andExpect(jsonPath("$.data[1].title").value("공지 제목 2"))
+                .andDo(restDocs.document(
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("공지사항 관련 API")
+                                        .description("북마크 기준 인기 공지사항 목록 조회")
+                                        .responseFields(
+                                                fieldWithPath("code").description("응답 코드"),
+                                                fieldWithPath("message").description("응답 메시지"),
+                                                fieldWithPath("status").description("상태"),
+                                                fieldWithPath("data[].id").description("공지ID"),
+                                                fieldWithPath("data[].title").description("공지제목"),
+                                                fieldWithPath("data[].categoryId").description("카테고리 ID"),
+                                                fieldWithPath("data[].categoryName").description("카테고리 이름"),
+                                                fieldWithPath("data[].link").description("공지 링크"),
+                                                fieldWithPath("data[].pubDate").description("발행일"),
+                                                fieldWithPath("data[].author").description("작성자"),
+                                                fieldWithPath("data[].description").description("설명")
+                                        )
+                                        .build()
+                        )
+                ));
+    }
 }

--- a/src/test/java/ku_rum/backend/domain/notice/presentation/NoticeControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/notice/presentation/NoticeControllerTest.java
@@ -133,9 +133,9 @@ public class NoticeControllerTest extends RestDocsTestSupport {
     void getPopularNotices() throws Exception {
         // given
         List<NoticeResponse> fakeResponse = List.of(
-                new NoticeResponse(1L, 1L, "link1", "공지 제목 1", "내용 1", "date1", "작성장1", "설명1"),
-                new NoticeResponse(2L, 2L, "link2", "공지 제목 2", "내용 2", "date2", "작성장2", "설명2"),
-                new NoticeResponse(3L, 3L, "link3", "공지 제목 3", "내용 3", "date3", "작성장3", "설명3")
+                new NoticeResponse(1L, 1L, "학사", "공지 제목 1", "https://link1.com", "2024-01-01", "관리자", "설명1"),
+                new NoticeResponse(2L, 2L, "학사", "공지 제목 2", "https://link2.com", "2024-01-02", "관리자", "설명2"),
+                new NoticeResponse(3L, 3L, "장학", "공지 제목 3", "https://link3.com", "2024-01-03", "관리자", "설명3")
         );
 
         given(noticeService.findPopularNotice())


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closes #329 

## 📝작업 내용
- [x] 인기 공지 API추가

## 작업 상세 내용
- 제목과 같습니다
- 이제서야 제대로 동작하는 restdocs test..

## 💬리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 북마크 수 기준 상위 3개 인기 공지사항 조회 기능 추가
  * 인기 공지사항 조회용 공개 API 엔드포인트 추가 (/api/v1/notices/popular)

* **테스트**
  * 인기 공지사항 조회 기능에 대한 컨트롤러 단위 테스트 추가 및 응답 검증

* **문서화**
  * 인기 공지사항 API 응답 필드 문서화(REST Docs) 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->