### PR TITLE
[refactor] 소셜 로그인 첫 회원가입 시, 로그인 정보를 온전히 받고 저장하도록 수정

### DIFF
--- a/src/main/java/ku_rum/backend/domain/auth/application/AuthService.java
+++ b/src/main/java/ku_rum/backend/domain/auth/application/AuthService.java
@@ -30,7 +30,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.*;
+import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.DELETED_MEMBER;
+import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.MALFORMED_TOKEN;
+import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.NO_SUCH_USER;
 
 @Slf4j
 @Service

--- a/src/main/java/ku_rum/backend/domain/auth/dto/request/SignupCompleteRequest.java
+++ b/src/main/java/ku_rum/backend/domain/auth/dto/request/SignupCompleteRequest.java
@@ -1,0 +1,12 @@
+package ku_rum.backend.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record SignupCompleteRequest(
+        @NotBlank String token,     // 프리사인업 토큰
+        @NotBlank String nickname,
+        String studentId,
+        String imageUrl
+) { }

--- a/src/main/java/ku_rum/backend/domain/department/application/DepartmentQueryService.java
+++ b/src/main/java/ku_rum/backend/domain/department/application/DepartmentQueryService.java
@@ -28,6 +28,12 @@ public class DepartmentQueryService {
                 .orElseThrow(() -> new NoSuchDepartmentException(NO_SUCH_DEPARTMENT));
     }
 
+    public Department getDepartment(final String departmentName) {
+        log.debug("학과 정보 검색: department={}", departmentName);
+        return departmentRepository.findFirstByName(departmentName)
+                .orElseThrow(() -> new NoSuchDepartmentException(NO_SUCH_DEPARTMENT));
+    }
+
     public CollegeDepartmentResponse getDepartmentsByCollege(final String college) {
         List<Department> departments = departmentRepository.findAllByCollege_Name(college);
         List<String> list = departments.stream().map(Department::getName).toList();

--- a/src/main/java/ku_rum/backend/domain/oauth/application/CustomOAuth2UserService.java
+++ b/src/main/java/ku_rum/backend/domain/oauth/application/CustomOAuth2UserService.java
@@ -1,8 +1,9 @@
 package ku_rum.backend.domain.oauth.application;
 
 import ku_rum.backend.domain.oauth.domain.OAuth2MemberInfo;
-import ku_rum.backend.domain.oauth.handler.OAuth2MemberInfoFactory;
+import ku_rum.backend.domain.oauth.domain.PreSignupPrincipal;
 import ku_rum.backend.domain.oauth.domain.ProviderType;
+import ku_rum.backend.domain.oauth.handler.OAuth2MemberInfoFactory;
 import ku_rum.backend.domain.user.domain.User;
 import ku_rum.backend.domain.user.domain.repository.UserRepository;
 import ku_rum.backend.global.exception.oauth.OAuthProviderMissMatchException;
@@ -34,32 +35,26 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     }
 
     private OAuth2User process(OAuth2UserRequest userRequest, OAuth2User user) {
-        ProviderType providerType = ProviderType.valueOf(userRequest.getClientRegistration().getRegistrationId().toUpperCase());
+        ProviderType providerType =
+                ProviderType.valueOf(userRequest.getClientRegistration().getRegistrationId().toUpperCase());
 
-        OAuth2MemberInfo memberInfo = OAuth2MemberInfoFactory.getOauth2MemberInfo(providerType, user.getAttributes());
+        OAuth2MemberInfo memberInfo =
+                OAuth2MemberInfoFactory.getOauth2MemberInfo(providerType, user.getAttributes());
+
         Optional<User> userOptional = userRepository.findByOauthId(memberInfo.getId());
 
-        User member;
         if (userOptional.isPresent()) {
-            member = userOptional.get();
+            User member = userOptional.get();
             if (providerType != member.getProviderType()) {
                 throw new OAuthProviderMissMatchException(
-                        "Looks like you're signed up with " + providerType +
-                                " account. Please use your " + member.getProviderType() + " account to login."
+                        "이미 " + member.getProviderType() + "로 가입된 계정입니다. 해당 계정으로 로그인해주세요."
                 );
             }
-            if (member.isFirstLogin()) {
-                member.changeFirstLogin(false);
-                userRepository.save(member);
-            }
-        } else {
-            member = createUser(memberInfo, providerType);
+            // 로그인 시점에는 더 이상 isFirstLogin을 변경/저장하지 않음
+            return CustomUserDetails.create(member, user.getAttributes());
         }
-        return CustomUserDetails.create(member, user.getAttributes());
-    }
 
-    private User createUser(OAuth2MemberInfo memberInfo, ProviderType providerType) {
-        User user = User.createMemberWithOAuthInfo(memberInfo, providerType);
-        return userRepository.save(user);
+        // 신규 유입: 아직 회원가입 전 —> PreSignupPrincipal 반환 (가입 보류)
+        return PreSignupPrincipal.of(providerType, memberInfo, user.getAttributes());
     }
 }

--- a/src/main/java/ku_rum/backend/domain/oauth/domain/PreSignupPrincipal.java
+++ b/src/main/java/ku_rum/backend/domain/oauth/domain/PreSignupPrincipal.java
@@ -1,0 +1,33 @@
+package ku_rum.backend.domain.oauth.domain;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class PreSignupPrincipal implements OAuth2User {
+
+    private final ProviderType providerType;
+    private final String oauthId;
+    private final String email;
+    private final Map<String, Object> attributes;
+
+    private PreSignupPrincipal(ProviderType providerType, String oauthId, String email, Map<String, Object> attributes) {
+        this.providerType = providerType;
+        this.oauthId = oauthId;
+        this.email = email;
+        this.attributes = attributes;
+    }
+
+    public static PreSignupPrincipal of(ProviderType providerType, OAuth2MemberInfo info, Map<String, Object> attrs) {
+        return new PreSignupPrincipal(providerType, info.getId(), info.getEmail(), attrs);
+    }
+
+    @Override public Map<String, Object> getAttributes() { return attributes; }
+    @Override public Collection<? extends GrantedAuthority> getAuthorities() { return List.of(); }
+    @Override public String getName() { return oauthId; }
+}

--- a/src/main/java/ku_rum/backend/domain/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/ku_rum/backend/domain/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -4,6 +4,7 @@ import com.github.dockerjava.api.exception.BadRequestException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import ku_rum.backend.domain.oauth.domain.PreSignupPrincipal;
 import ku_rum.backend.domain.oauth.util.AppProperties;
 import ku_rum.backend.domain.oauth.util.CookieUtils;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +24,8 @@ import static ku_rum.backend.domain.oauth.handler.HttpCookieOAuth2AuthorizationR
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final AppProperties appProperties;
-    private final TempTokenProvider tokenProvider;
+    private final TempTokenProvider tempTokenProvider;             // 기존 가입자용 임시토큰
+    private final PreSignupTokenProvider preSignupTokenProvider;   // 신규: 프리사인업 토큰
     private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
 
     @Override
@@ -50,10 +52,22 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
         String targetUrl = redirectUri.orElse(getDefaultTargetUrl());
 
-        String token = tokenProvider.createTempToken(authentication);
+        Object principal = authentication.getPrincipal();
 
+        if (principal instanceof PreSignupPrincipal pre) {
+            // 미가입자 —> 프리사인업 토큰 발급
+            String preToken = preSignupTokenProvider.create(pre);
+            return UriComponentsBuilder.fromUriString(targetUrl)
+                    .queryParam("needSignup", true)
+                    .queryParam("token", preToken)
+                    .build().toUriString();
+        }
+
+        // 기존 가입자 —> 임시토큰(=userId 바인딩) 발급 (기존 교환 플로우 유지)
+        String tempToken = tempTokenProvider.createTempToken(authentication);
         return UriComponentsBuilder.fromUriString(targetUrl)
-                .queryParam("token", token)
+                .queryParam("needSignup", false)
+                .queryParam("token", tempToken)
                 .build().toUriString();
     }
 
@@ -64,7 +78,6 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
     private boolean isAuthorizedRedirectUri(String uri) {
         URI clientRedirectUri = URI.create(uri);
-
         return appProperties.getOauth2().getAuthorizedRedirectUris()
                 .stream()
                 .anyMatch(authorizedRedirectUri -> {

--- a/src/main/java/ku_rum/backend/domain/oauth/handler/PreSignupTokenProvider.java
+++ b/src/main/java/ku_rum/backend/domain/oauth/handler/PreSignupTokenProvider.java
@@ -1,0 +1,76 @@
+package ku_rum.backend.domain.oauth.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.JwtException;
+import ku_rum.backend.domain.oauth.domain.PreSignupPrincipal;
+import ku_rum.backend.domain.oauth.domain.ProviderType;
+import ku_rum.backend.global.utill.RedisUtil;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class PreSignupTokenProvider {
+
+    private final RedisUtil redisUtil;
+    private static final long PRE_SIGNUP_EXPIRY_MILLIS = 30 * 60 * 1000; // 30분
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public String create(PreSignupPrincipal pre) {
+        String token = UUID.randomUUID().toString();
+        PreSignupPayload payload = new PreSignupPayload(
+                pre.getProviderType(),
+                pre.getOauthId(),
+                pre.getEmail(),
+                pre.getAttributes()
+        );
+        redisUtil.setRedisData(key(token), toJson(payload), PRE_SIGNUP_EXPIRY_MILLIS);
+        return token;
+    }
+
+    public PreSignupPayload resolve(String token) {
+        String json = redisUtil.getRedisData(key(token));
+        if (json == null) {
+            throw new JwtException("유효하지 않은 프리사인업 토큰입니다");
+        }
+        return fromJson(json);
+    }
+
+    public void invalidate(String token) {
+        redisUtil.deleteRedisData(key(token));
+    }
+
+    private String key(String token) {
+        return "PRE_SIGNUP:" + token;
+    }
+
+    private String toJson(PreSignupPayload payload) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(payload);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private PreSignupPayload fromJson(String json) {
+        try {
+            return OBJECT_MAPPER.readValue(json, PreSignupPayload.class);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class PreSignupPayload {
+        private ProviderType providerType;
+        private String oauthId;
+        private String email; // nullable
+        private Map<String, Object> attributes; // 원시 속성 (필요시 사용할 수 있음)
+    }
+}

--- a/src/main/java/ku_rum/backend/domain/user/application/UserService.java
+++ b/src/main/java/ku_rum/backend/domain/user/application/UserService.java
@@ -1,6 +1,6 @@
 package ku_rum.backend.domain.user.application;
 
-import jakarta.servlet.http.HttpServletRequest;
+import ku_rum.backend.domain.auth.dto.response.AuthResponse;
 import ku_rum.backend.domain.common.mail.application.MailService;
 import ku_rum.backend.domain.department.application.DepartmentQueryService;
 import ku_rum.backend.domain.department.application.UserDepartmentService;
@@ -8,28 +8,43 @@ import ku_rum.backend.domain.department.domain.Department;
 import ku_rum.backend.domain.department.domain.UserDepartment;
 import ku_rum.backend.domain.department.domain.repository.DepartmentRepository;
 import ku_rum.backend.domain.department.domain.repository.UserDepartmentRepository;
+import ku_rum.backend.domain.department.dto.DepartmentResponse;
+import ku_rum.backend.domain.oauth.handler.PreSignupTokenProvider;
 import ku_rum.backend.domain.user.domain.User;
 import ku_rum.backend.domain.user.domain.repository.UserRepository;
-import ku_rum.backend.domain.user.dto.request.*;
-import ku_rum.backend.domain.user.dto.response.*;
+import ku_rum.backend.domain.user.dto.request.InitiatePasswordResetRequest;
+import ku_rum.backend.domain.user.dto.request.NicknameChangeRequest;
+import ku_rum.backend.domain.user.dto.request.ProfileChangeRequest;
+import ku_rum.backend.domain.user.dto.request.ResetPasswordRequest;
+import ku_rum.backend.domain.user.dto.request.SocialSignupRequest;
+import ku_rum.backend.domain.user.dto.request.UserSaveRequest;
+import ku_rum.backend.domain.user.dto.response.LoginIdResponse;
+import ku_rum.backend.domain.user.dto.response.UserResponse;
+import ku_rum.backend.domain.user.dto.response.UserSaveResponse;
 import ku_rum.backend.global.exception.department.DuplicateDepartmentException;
 import ku_rum.backend.global.exception.department.NoSuchDepartmentException;
 import ku_rum.backend.global.exception.global.GlobalException;
 import ku_rum.backend.global.exception.user.DuplicateNicknameException;
 import ku_rum.backend.global.exception.user.NoSuchUserException;
-import ku_rum.backend.global.exception.user.UserMapBuildingNotFoundException;
-import ku_rum.backend.global.utill.LocationUtils;
+import ku_rum.backend.global.security.CustomUserDetails;
+import ku_rum.backend.global.security.JwtTokenProvider;
 import ku_rum.backend.global.utill.UserUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Comparator;
 import java.util.List;
 
-import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.*;
+import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.DUPLICATE_DEPARTMENT;
+import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.DUPLICATE_NICKNAME;
+import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.NO_SUCH_DEPARTMENT;
+import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.NO_SUCH_USER;
+import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.PREV_NEW_EQUAL_EXCEPTION;
 
 @Service
 @Transactional(readOnly = true)
@@ -45,7 +60,8 @@ public class UserService {
     private final DepartmentRepository departmentRepository;
     private final UserDepartmentService userDepartmentService;
     private final MailService mailService;
-    private final UserUtil userUtil;
+    private final PreSignupTokenProvider preSignupTokenProvider;
+    private final JwtTokenProvider jwtTokenProvider;
 
     // 소셜 로그인 X
     @Transactional
@@ -63,20 +79,42 @@ public class UserService {
         return UserSaveResponse.from(userRepository.save(user));
     }
 
-    // 소셜 로그인 전용 회원 가입 토큰 필요
+    /**
+     * 프리사인업 토큰으로 소셜 가입 완료 + 즉시 로그인(JWT 발급)
+     */
     @Transactional
-    public UserSaveResponse saveUserBySocial(final UserSaveRequest userSaveRequest) {
-        log.info("사용자 저장 요청: {}", userSaveRequest);
-        userValidator.validateUser(userSaveRequest);
+    public AuthResponse completeSocialSignup(final SocialSignupRequest req) {
+        log.info("소셜 가입 요청: {}", req);
 
-        Department department = departmentQueryService.getDepartment(userSaveRequest);
-        User user = userUtil.getUser();
-        user.changeProfile(userSaveRequest, passwordEncoder.encode(userSaveRequest.password()));
+        PreSignupTokenProvider.PreSignupPayload payload = preSignupTokenProvider.resolve(req.token());
+
+        userRepository.findByOauthId(payload.getOauthId()).ifPresent(u -> {
+            throw new BadCredentialsException("이미 가입된 계정입니다. 로그인해주세요.");
+        });
+
+        Department department = departmentQueryService.getDepartment(req.department());
+
+
+        User user = User.builder()
+                .providerType(payload.getProviderType())
+                .oauthId(payload.getOauthId())
+                .studentId(req.studentId())
+                .nickname(req.nickname())
+                .agreementStatus(req.agreementStatus())
+                .build();
+        user.changeFirstLogin(false);
+        user = userRepository.save(user);
 
         userDepartmentService.addDeptToUser(user, department);
 
-        log.info("사용자 저장 완료: ID={}", userSaveRequest.loginId());
-        return UserSaveResponse.from(user);
+        preSignupTokenProvider.invalidate(req.token());
+
+        CustomUserDetails userDetails = CustomUserDetails.from(user);
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+
+        log.info("소셜 가입 완료: userId={}", user.getId());
+        return AuthResponse.of(jwtTokenProvider.createToken(authentication), buildUserResponse(user));
     }
 
     @Transactional
@@ -176,32 +214,21 @@ public class UserService {
         return userRepository.existsByNickname(nickname);
     }
 
-    @Transactional
-    public UserShareActiveResponse isShareActive() {
-        User currentUser = userUtil.getUser();
-        return new UserShareActiveResponse(currentUser.isActive());
-    }
+    private UserResponse buildUserResponse(User user) {
+        List<UserDepartment> byUserId = userDepartmentRepository.findByUserId(user.getId());
+        List<DepartmentResponse> list = byUserId.stream()
+                .map(UserDepartment::getDepartment)
+                .map(DepartmentResponse::of)
+                .toList();
 
-    @Transactional
-    public UserLocationShareStartResponse startShareLocation(UserLocationShareStartRequest request) {
-        //요청한 장소 이름 가져오기
-        String placePointed = request.placePointed();
-
-        //현재 로그인한 사용자 정보 가져오기
-        User currentUser = userUtil.getUser();
-
-        //사용자 위치 공유 활성화 상태 변경 및 activeBuildingName 변경
-        currentUser.changeActiveBuildingName(placePointed);
-        currentUser.setLocationSharingActive(true);
-
-        //응답용 DTO 생성 및 반환
-        return new UserLocationShareStartResponse(placePointed, true);
-    }
-
-    @Transactional
-    public UserShareActiveResponse changeToNotActive() {
-        User currentUser = userUtil.getUser();
-        currentUser.setLocationSharingActive(false);
-        return new UserShareActiveResponse(currentUser.isActive());
+        return UserResponse.of(
+                user.getId(),
+                user.getOauthId(),
+                user.getLoginId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getStudentId(),
+                user.getImageUrl(),
+                list);
     }
 }

--- a/src/main/java/ku_rum/backend/domain/user/dto/request/SocialSignupRequest.java
+++ b/src/main/java/ku_rum/backend/domain/user/dto/request/SocialSignupRequest.java
@@ -1,0 +1,26 @@
+package ku_rum.backend.domain.user.dto.request;
+
+import jakarta.validation.constraints.*;
+import ku_rum.backend.domain.user.domain.AgreementStatus;
+import lombok.Builder;
+
+@Builder
+public record SocialSignupRequest(
+        @NotBlank(message = "소셜 가입 토큰은 필수입니다.")
+        String token,
+
+        @NotNull(message = "학번 입력은 필수입니다.")
+        @Pattern(regexp = "^20(1[0-9]|2[0-5])\\d{5}$", message = "학번은 20으로 시작하고, 9자리여야 합니다.")
+        String studentId,
+
+        @NotNull(message = "학과 입력은 필수입니다.")
+        String department,
+
+        @NotBlank(message = "닉네임 입력은 필수입니다. 최대 8자 이하입니다.")
+        @Size(min = 2, max = 10)
+        String nickname,
+
+        @NotNull(message = "약관 동의 여부는 필수 입니다.")
+        AgreementStatus agreementStatus
+) {
+}

--- a/src/main/java/ku_rum/backend/domain/user/presentation/UserController.java
+++ b/src/main/java/ku_rum/backend/domain/user/presentation/UserController.java
@@ -1,17 +1,27 @@
 package ku_rum.backend.domain.user.presentation;
 
 import jakarta.validation.Valid;
-import ku_rum.backend.domain.user.application.UserValidator;
-import ku_rum.backend.domain.user.application.UserService;
+import ku_rum.backend.domain.auth.dto.response.AuthResponse;
 import ku_rum.backend.domain.common.mail.dto.request.EmailValidationRequest;
+import ku_rum.backend.domain.user.application.UserService;
+import ku_rum.backend.domain.user.application.UserValidator;
+import ku_rum.backend.domain.user.dto.request.SocialSignupRequest;
 import ku_rum.backend.domain.user.dto.request.UserSaveRequest;
 import ku_rum.backend.domain.user.dto.response.UserSaveResponse;
 import ku_rum.backend.global.support.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-import static ku_rum.backend.domain.user.domain.UserMessage.*;
+import static ku_rum.backend.domain.user.domain.UserMessage.VALID_EMAIL_MESSAGE;
+import static ku_rum.backend.domain.user.domain.UserMessage.VALID_LOGINID_MESSAGE;
+import static ku_rum.backend.domain.user.domain.UserMessage.VALID_NICKNAME_MESSAGE;
+import static ku_rum.backend.domain.user.domain.UserMessage.VALID_STUDENTID_MESSAGE;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -23,7 +33,6 @@ public class UserController {
 
     /**
      * 회원 가입 API
-     *
      * @param userSaveRequest
      * @return
      */
@@ -34,18 +43,15 @@ public class UserController {
 
     /**
      * 소셜 로그인 회원 가입 API (토큰 필요)
-     *
-     * @param userSaveRequest
      * @return
      */
     @PostMapping("/social")
-    public BaseResponse<UserSaveResponse> joinBySocial(@RequestBody @Valid final UserSaveRequest userSaveRequest) {
-        return BaseResponse.ok(userService.saveUserBySocial(userSaveRequest));
+    public BaseResponse<AuthResponse> joinBySocial(@RequestBody @Valid final SocialSignupRequest req) {
+        return BaseResponse.ok(userService.completeSocialSignup(req));
     }
 
     /**
      * 이메일 검증 API
-     *
      * @param emailValidationRequest
      * @return
      */
@@ -57,7 +63,6 @@ public class UserController {
 
     /**
      * 아이디 중복 확인 API
-     *
      * @param value
      * @return
      */
@@ -69,7 +74,6 @@ public class UserController {
 
     /**
      * 닉네임 중복 확인 API
-     *
      * @param value
      * @return
      */
@@ -81,7 +85,6 @@ public class UserController {
 
     /**
      * 학번 중복 확인 API
-     *
      * @param value
      * @return
      */

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -13,7 +13,7 @@ spring:
             enable: true
 
   datasource:
-    url: jdbc:mysql://127.0.0.1:3306/testdb
+    url: jdbc:mysql://127.0.0.1:3307/testdb
     username: root
     password: testdb
     hikari:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -13,7 +13,7 @@ spring:
             enable: true
 
   datasource:
-    url: jdbc:mysql://127.0.0.1:3307/testdb
+    url: jdbc:mysql://127.0.0.1:3306/testdb
     username: root
     password: testdb
     hikari:

--- a/src/test/java/ku_rum/backend/domain/user/presentation/UserControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/user/presentation/UserControllerTest.java
@@ -2,6 +2,7 @@ package ku_rum.backend.domain.user.presentation;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import ku_rum.backend.config.RestDocsTestSupport;
+import ku_rum.backend.domain.auth.dto.response.AuthResponse;
 import ku_rum.backend.domain.common.mail.dto.request.EmailValidationRequest;
 import ku_rum.backend.domain.friend.application.FriendReportService;
 import ku_rum.backend.domain.friend.domain.repository.FriendBlockRepository;
@@ -9,8 +10,11 @@ import ku_rum.backend.domain.user.application.UserService;
 import ku_rum.backend.domain.user.application.UserValidator;
 import ku_rum.backend.domain.user.domain.AgreementStatus;
 import ku_rum.backend.domain.user.dto.request.ProfileChangeRequest;
+import ku_rum.backend.domain.user.dto.request.SocialSignupRequest;
 import ku_rum.backend.domain.user.dto.request.UserSaveRequest;
 import ku_rum.backend.domain.user.dto.response.LoginIdResponse;
+import ku_rum.backend.domain.user.dto.response.TokenResponse;
+import ku_rum.backend.domain.user.dto.response.UserResponse;
 import ku_rum.backend.global.domain.repository.ApiLogRepository;
 import ku_rum.backend.global.security.CustomUserDetails;
 import org.junit.jupiter.api.DisplayName;
@@ -28,13 +32,22 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static ku_rum.backend.domain.user.domain.UserMessage.*;
+import static ku_rum.backend.domain.user.domain.UserMessage.VALID_LOGINID_MESSAGE;
+import static ku_rum.backend.domain.user.domain.UserMessage.VALID_NICKNAME_MESSAGE;
+import static ku_rum.backend.domain.user.domain.UserMessage.VALID_STUDENTID_MESSAGE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -143,13 +156,11 @@ class UserControllerTest extends RestDocsTestSupport {
     @WithMockUser
     void createUserBySocial() throws Exception {
         //given
-        UserSaveRequest request = UserSaveRequest.builder()
-                .email("kmw106933@konkuk.ac.kr")
-                .loginId("kmw106933")
-                .password("password123")
+        SocialSignupRequest request = SocialSignupRequest.builder()
                 .department("컴퓨터공학부")
                 .nickname("미미미누")
                 .studentId("202112322")
+                .token("asfsdfdsdf12123")
                 .agreementStatus(AgreementStatus.AGREED)
                 .build();
 
@@ -172,38 +183,34 @@ class UserControllerTest extends RestDocsTestSupport {
                                         headerWithName("Authorization").description("발급 받은 엑세스 토큰입니다.")
                                 )
                                 .requestFields(
-                                        fieldWithPath("loginId")
-                                                .type(JsonType.STRING)
-                                                .description("멤버 아이디")
-                                                .attributes(constraints("아이디 입력은 필수입니다. 최소 6자 이상입니다.")),
-                                        fieldWithPath("email")
-                                                .type(JsonType.STRING)
-                                                .description("멤버 이메일")
-                                                .attributes(constraints("유저의 이메일")),
-                                        fieldWithPath("nickname")
-                                                .type(JsonType.STRING)
-                                                .description("멤버 닉네임")
-                                                .attributes(constraints("닉네임 입력은 필수입니다. 최대 8자 이하입니다.")),
-                                        fieldWithPath("password")
-                                                .type(JsonType.STRING)
-                                                .description("멤버 패스워드")
-                                                .attributes(constraints("비밀번호는 영어와 숫자를 포함해서 8자 이상 20자 이내로 입력해주세요.")),
+                                        fieldWithPath("token")
+                                                .type(JsonFieldType.STRING)
+                                                .description("소셜 가입 토큰")
+                                                .attributes(constraints("소셜 로그인 성공 시 발급되는 프리사인업 토큰")),
+
                                         fieldWithPath("studentId")
-                                                .type(JsonType.STRING)
-                                                .description("멤버 학번")
-                                                .attributes(constraints("학번은 20으로 시작하고, 9자리여야 합니다.")),
+                                                .type(JsonFieldType.STRING)
+                                                .description("학번")
+                                                .attributes(constraints("20으로 시작하는 9자리 학번 (예: 202112322)")),
+
                                         fieldWithPath("department")
-                                                .type(JsonType.STRING)
-                                                .description("멤버 학과")
-                                                .attributes(constraints("ex) 컴퓨터공학부")),
+                                                .type(JsonFieldType.STRING)
+                                                .description("학과")
+                                                .attributes(constraints("예: 컴퓨터공학부")),
+
+                                        fieldWithPath("nickname")
+                                                .type(JsonFieldType.STRING)
+                                                .description("닉네임")
+                                                .attributes(constraints("2~10자, 중복 불가")),
+
                                         fieldWithPath("agreementStatus")
-                                                .type(JsonType.STRING)
-                                                .description("선택 동의 여부")
-                                                .attributes(constraints("ex) AGREED/DISAGREED"))
+                                                .type(JsonFieldType.STRING)
+                                                .description("약관 동의 여부")
+                                                .attributes(constraints("AGREED 또는 DISAGREED"))
                                 )
                                 .responseFields(
                                         fieldWithPath("code")
-                                                .type(JsonType.STRING)
+                                                .type(JsonType.NUMBER)
                                                 .description("성공시 반환 코드 (200)"),
                                         fieldWithPath("status")
                                                 .type(JsonType.STRING)
@@ -303,6 +310,129 @@ class UserControllerTest extends RestDocsTestSupport {
                                                         .description("성공 시 반환 메시지")
                                         ).build())));
     }
+
+    @Test
+    @DisplayName("소셜 로그인 회원가입을 완료한다.")
+    @WithMockUser
+    void completeSocialSignup() throws Exception {
+        // given
+        SocialSignupRequest request = SocialSignupRequest.builder()
+                .token("b9a0e2c6-7b35-4d3b-8b2e-25a7eac2fbc7")
+                .studentId("202312345")
+                .department("컴퓨터공학과")
+                .nickname("민우")
+                .agreementStatus(AgreementStatus.AGREED)
+                .build();
+
+        AuthResponse mockResponse = AuthResponse.of(
+                new TokenResponse("accessToken123", "refreshToken123", 123, 123, true),
+                UserResponse.of(
+                        1L, "kakao_2392032", null, "user@konkuk.ac.kr",
+                        "민우", "202312345", "https://image.kuroom.shop/1.png", List.of()
+                )
+        );
+
+        given(userService.completeSocialSignup(any(SocialSignupRequest.class)))
+                .willReturn(mockResponse);
+
+        // when then
+        mockMvc.perform(post("/api/v1/users/social")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .header("Authorization", "Bearer testAccessToken")
+                        .with(SecurityMockMvcRequestPostProcessors.user(
+                                CustomUserDetails.of(1L, "testUser",
+                                        AuthorityUtils.createAuthorityList("ROLE_USER"), "kakao_2392032", false)
+                        ))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("소셜 로그인 API")
+                                        .description("소셜 로그인 회원가입 완료 API — 프리사인업 토큰을 이용해 회원 정보를 등록하고 JWT를 발급받습니다.")
+                                        .requestHeaders(
+                                                headerWithName("Authorization").description("발급받은 임시 접근 토큰 또는 Bearer 헤더 (테스트용)")
+                                        )
+                                        .requestFields(
+                                                fieldWithPath("token")
+                                                        .type(JsonFieldType.STRING)
+                                                        .description("프리사인업 토큰 (PreSignupTokenProvider에서 발급된 1회용 토큰)")
+                                                        .attributes(constraints("소셜 로그인 성공 시 프론트로 전달된 토큰을 그대로 전송합니다.")),
+                                                fieldWithPath("studentId")
+                                                        .type(JsonFieldType.STRING)
+                                                        .description("학번 (예: 202312345)")
+                                                        .attributes(constraints("9자리 학번, 20으로 시작해야 합니다.")),
+                                                fieldWithPath("department")
+                                                        .type(JsonFieldType.STRING)
+                                                        .description("학과 이름")
+                                                        .attributes(constraints("예: 컴퓨터공학과")),
+                                                fieldWithPath("nickname")
+                                                        .type(JsonFieldType.STRING)
+                                                        .description("닉네임 (2~10자)")
+                                                        .attributes(constraints("특수문자 제외, 중복 불가")),
+                                                fieldWithPath("agreementStatus")
+                                                        .type(JsonFieldType.STRING)
+                                                        .description("약관 동의 상태 (예: AGREED)")
+                                                        .attributes(constraints("반드시 AGREED 여야 합니다."))
+                                        )
+                                        .responseFields(
+                                                // tokenResponse
+                                                fieldWithPath("data.tokenResponse.accessToken")
+                                                        .type(JsonFieldType.STRING)
+                                                        .description("Access Token"),
+                                                fieldWithPath("data.tokenResponse.refreshToken")
+                                                        .type(JsonFieldType.STRING)
+                                                        .description("Refresh Token"),
+                                                fieldWithPath("data.tokenResponse.accessExpireIn")
+                                                        .type(JsonFieldType.NUMBER)
+                                                        .description("Access Token 만료까지 남은 시간(초)"),
+                                                fieldWithPath("data.tokenResponse.refreshExpireIn")
+                                                        .type(JsonFieldType.NUMBER)
+                                                        .description("Refresh Token 만료까지 남은 시간(초)"),
+                                                fieldWithPath("data.tokenResponse.isFirstLogin")
+                                                        .type(JsonFieldType.BOOLEAN)
+                                                        .description("첫 로그인 여부"),
+
+                                                // userResponse (여기가 핵심!)
+                                                subsectionWithPath("data.userResponse")
+                                                        .type(JsonFieldType.OBJECT)
+                                                        .description("회원 정보 객체"),
+
+                                                fieldWithPath("data.userResponse.id")
+                                                        .type(JsonFieldType.NUMBER)
+                                                        .description("회원 고유 ID"),
+                                                fieldWithPath("data.userResponse.oauthId")
+                                                        .type(JsonFieldType.STRING)
+                                                        .description("OAuth ID").optional(),
+                                                fieldWithPath("data.userResponse.loginId")
+                                                        .type(JsonFieldType.STRING)
+                                                        .description("로그인 ID").optional(),
+                                                fieldWithPath("data.userResponse.email")
+                                                        .type(JsonFieldType.STRING)
+                                                        .description("이메일").optional(),
+                                                fieldWithPath("data.userResponse.nickname")
+                                                        .type(JsonFieldType.STRING)
+                                                        .description("닉네임"),
+                                                fieldWithPath("data.userResponse.studentId")
+                                                        .type(JsonFieldType.STRING)
+                                                        .description("학번"),
+                                                fieldWithPath("data.userResponse.imageUrl")
+                                                        .type(JsonFieldType.STRING)
+                                                        .description("프로필 이미지 URL").optional(),
+                                                fieldWithPath("data.userResponse.departmentResponse")
+                                                        .type(JsonFieldType.ARRAY)
+                                                        .description("학과 리스트").optional(),
+                                                fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드 (200)"),
+                                                fieldWithPath("status").type(JsonFieldType.STRING).description("응답 상태 (OK)"),
+                                                fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")
+                                        )
+                                        .build()
+                        )
+                ));
+    }
+
 
     @DisplayName("아이디 중복 여부를 확인한다.")
     @Test


### PR DESCRIPTION
## 📝작업 내용
- [x] 소셜 로그인 첫 회원가입 시, 로그인 정보를 온전히 받고 저장하도록 수정

```
[User] 
   ↓ (소셜 로그인 클릭)
[Frontend] ───→ /oauth2/authorization/kakao
   ↓
[Backend - Spring Security OAuth2] 
   ↓ (카카오 인증 성공)
[CustomOAuth2UserService]
   ↳ 신규? → PreSignupPrincipal 
   ↳ 기존? → CustomUserDetails
   ↓
[OAuth2AuthenticationSuccessHandler]
   ↳ 신규 → PreSignupToken 생성 → redirect needSignup=true&token
   ↳ 기존 → TempToken 생성 → redirect needSignup=false&token
   ↓
[Frontend /social/callback]
   ↳ needSignup=true → 회원가입 폼 표시
   ↳ needSignup=false → /api/v1/auth/token 호출
   ↓
[Backend]
   ↳ /auth/token → Access/Refresh 발급 (기존)
   ↳ /users/social → 회원가입 + Access/Refresh 발급 (신규)
   ↓
[Frontend]
   ↳ JWT 저장 후 메인화면으로 이동
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * OAuth2 소셜 로그인 프로세스 개선 및 토큰 기반 인증 추가
  * 신규 사용자 가입 시 토큰 검증 및 추가 정보 수집 기능 추가

* **개선 사항**
  * 가입 요청 데이터 구조 최적화 (학번, 부서, 닉네임, 동의 상태 포함)
  * 부서 검색 기능 확장

<!-- end of auto-generated comment: release notes by coderabbit.ai -->