### PR TITLE
[FEAT] 알림 확인 API

### DIFF
--- a/src/main/java/ku_rum/backend/domain/alarm/application/AlarmService.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/application/AlarmService.java
@@ -18,6 +18,7 @@ import ku_rum.backend.domain.alarm.dto.request.PatchAlarmRequest;
 import ku_rum.backend.domain.alarm.dto.response.AlarmPaginationRequest;
 import ku_rum.backend.domain.alarm.dto.response.GetAlarmDto;
 import ku_rum.backend.domain.alarm.dto.response.GetAlarmResponse;
+import ku_rum.backend.domain.alarm.dto.response.GetAlarmUnreadResponse;
 import ku_rum.backend.domain.alarm.dto.response.PatchAlarmResponse;
 import ku_rum.backend.domain.user.application.UserService;
 import ku_rum.backend.domain.user.domain.User;
@@ -102,6 +103,13 @@ public class AlarmService {
             return patchAlarm(userId, request.alarmId());
         }
         return patchAnnouncement(userId, request.alarmId());
+    }
+
+    public GetAlarmUnreadResponse getAlarmUnreadResponse(CustomUserDetails userDetails) {
+        User user = userService.getUser();
+        long unCheckedAlarm = alarmRepository.countByUserAndIsCheckedFalse(user);
+        long unCheckAnnouncementCount = userAnnouncementRepository.countByUserAndIsCheckedFalse(user);
+        return GetAlarmUnreadResponse.of(unCheckedAlarm, unCheckAnnouncementCount);
     }
 
     private PatchAlarmResponse patchAlarm(Long userId, Long alarmId) {

--- a/src/main/java/ku_rum/backend/domain/alarm/application/AlarmService.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/application/AlarmService.java
@@ -182,12 +182,19 @@ public class AlarmService {
                 throw new GlobalException(BaseExceptionResponseStatus.INVALID_CURSOR_FORMAT);
             }
             try {
-                lastAlarmId = Long.valueOf(parts[0]);
-                lastAnnouncementId = Long.valueOf(parts[1]);
+                lastAlarmId = getCursorPoint(parts[0]);
+                lastAnnouncementId = getCursorPoint(parts[1]);
             } catch (NumberFormatException e) {
                 throw new GlobalException(BaseExceptionResponseStatus.INVALID_CURSOR_FORMAT);
             }
         }
         return new AlarmCursorDto(lastAlarmId, lastAnnouncementId);
+    }
+
+    private Long getCursorPoint(String cursorPoint) {
+        if (cursorPoint.equals("null")) {
+            return null;
+        }
+        return Long.valueOf(cursorPoint);
     }
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/application/AlarmService.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/application/AlarmService.java
@@ -4,6 +4,7 @@ package ku_rum.backend.domain.alarm.application;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 import ku_rum.backend.domain.alarm.domain.Alarm;
 import ku_rum.backend.domain.alarm.domain.AlarmCategory;
@@ -89,9 +90,9 @@ public class AlarmService {
         boolean hasNext = totalFetched > request.limit();
         String nextCursor = null;
         if (hasNext && !merged.isEmpty()) {
-            GetAlarmDto lastItem = merged.get(merged.size() - 1);
+            GetAlarmDto nextItem = merged.get(merged.size() - 1);
 
-            nextCursor = getNextCursor(alarmCursorDto, alarms, userAnnouncements, lastItem);
+            nextCursor = getNextCursor(alarmCursorDto, alarms, userAnnouncements, nextItem);
         }
         return new GetAlarmResponse(merged, hasNext, nextCursor);
     }
@@ -157,17 +158,11 @@ public class AlarmService {
 
     private String getNextCursor(AlarmCursorDto alarmCursorDto, List<Alarm> alarms,
                                  List<UserAnnouncement> userAnnouncements, GetAlarmDto lastItem) {
-        Long nextAlarmId = alarms.stream()
-                .filter(a -> a.getCreatedAt().isBefore(lastItem.createdAt()))
-                .map(Alarm::getId)
-                .max(Long::compareTo)
-                .orElse(alarmCursorDto.lastAlarmId());
+        Long fallbackAlarmId = getFallbackAlarmId(alarmCursorDto);
+        Long fallbackAnnouncementId = getFallbackAnnouncementId(alarmCursorDto);
 
-        Long nextAnnouncementId = userAnnouncements.stream()
-                .filter(ua -> ua.getAnnouncement().getCreatedAt().isBefore(lastItem.createdAt()))
-                .map(UserAnnouncement::getId)
-                .max(Long::compareTo)
-                .orElse(alarmCursorDto.lastAnnouncementId());
+        Long nextAlarmId = getNextAlarmId(alarms, lastItem, fallbackAlarmId);
+        Long nextAnnouncementId = getNextAnnouncementId(userAnnouncements, lastItem, fallbackAnnouncementId);
 
         return nextAlarmId + "_" + nextAnnouncementId;
     }
@@ -196,5 +191,49 @@ public class AlarmService {
             return null;
         }
         return Long.valueOf(cursorPoint);
+    }
+
+    private Long getFallbackAlarmId(AlarmCursorDto cursor) {
+        if (cursor == null) {
+            return -1L;
+        }
+        if (cursor.lastAlarmId() == null) {
+            return -1L;
+        }
+        return cursor.lastAlarmId();
+    }
+
+    private Long getFallbackAnnouncementId(AlarmCursorDto cursor) {
+        if (cursor == null) {
+            return -1L;
+        }
+        if (cursor.lastAnnouncementId() == null) {
+            return -1L;
+        }
+        return cursor.lastAnnouncementId();
+    }
+
+    private Long getNextAlarmId(List<Alarm> alarms, GetAlarmDto lastItem, Long fallback) {
+        Optional<Alarm> optional = alarms.stream()
+                .filter(a -> a.getCreatedAt().isBefore(lastItem.createdAt()))
+                .max(Comparator.comparing(Alarm::getCreatedAt));
+
+        if (!optional.isPresent()) {
+            return fallback;
+        }
+
+        return optional.get().getId();
+    }
+
+    private Long getNextAnnouncementId(List<UserAnnouncement> list, GetAlarmDto lastItem, Long fallback) {
+        Optional<UserAnnouncement> optional = list.stream()
+                .filter(ua -> ua.getAnnouncement().getCreatedAt().isBefore(lastItem.createdAt()))
+                .max(Comparator.comparing(ua -> ua.getAnnouncement().getCreatedAt()));
+
+        if (!optional.isPresent()) {
+            return fallback;
+        }
+
+        return optional.get().getId();
     }
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/application/FriendPlaceSharingHandler.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/application/FriendPlaceSharingHandler.java
@@ -12,7 +12,7 @@ public class FriendPlaceSharingHandler implements AlarmMessageHandler {
     @Override
     public Alarm create(AlarmType alarmType, Object object, User user) {
         UserPlaceAlarmDto userPlaceAlarmDto = (UserPlaceAlarmDto) object;
-        String message = String.format("%s 님이 위치를 공유했어요. 친구 위치를 확인해보세요.", userPlaceAlarmDto.user());
+        String message = String.format("%s 님이 위치를 공유했어요. 친구 위치를 확인해보세요.", userPlaceAlarmDto.user().getNickname());
         return Alarm.builder()
                 .alarmType(alarmType)
                 .message(message)

--- a/src/main/java/ku_rum/backend/domain/alarm/domain/repository/AlarmRepository.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/domain/repository/AlarmRepository.java
@@ -22,4 +22,6 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     List<Alarm> findAlarms(@Param("user") User user, @Param("lastId") Long lastId, Pageable pageable);
 
     Optional<Alarm> findById(Long AlarmId);
+
+    long countByUserAndIsCheckedFalse(User user);
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/domain/repository/AlarmRepository.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/domain/repository/AlarmRepository.java
@@ -16,7 +16,7 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     @Query("""
             SELECT a FROM Alarm a
             WHERE a.user = :user
-              AND (:lastId IS NULL OR a.id < :lastId)
+              AND (:lastId IS NULL OR a.id <= :lastId)
             ORDER BY a.createdAt desc 
             """)
     List<Alarm> findAlarms(@Param("user") User user, @Param("lastId") Long lastId, Pageable pageable);

--- a/src/main/java/ku_rum/backend/domain/alarm/domain/repository/UserAnnouncementRepository.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/domain/repository/UserAnnouncementRepository.java
@@ -17,7 +17,7 @@ public interface UserAnnouncementRepository extends JpaRepository<UserAnnounceme
             FROM UserAnnouncement ua
             JOIN ua.announcement a
             WHERE ua.user = :user
-              AND (:lastId IS NULL OR ua.id < :lastId)
+              AND (:lastId IS NULL OR ua.id <= :lastId)
             ORDER BY ua.createdAt DESC
             """)
     List<UserAnnouncement> findUserAnnouncement(@Param("user") User user, @Param("lastId") Long lastId,

--- a/src/main/java/ku_rum/backend/domain/alarm/domain/repository/UserAnnouncementRepository.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/domain/repository/UserAnnouncementRepository.java
@@ -22,4 +22,6 @@ public interface UserAnnouncementRepository extends JpaRepository<UserAnnounceme
             """)
     List<UserAnnouncement> findUserAnnouncement(@Param("user") User user, @Param("lastId") Long lastId,
                                                 Pageable pageable);
+
+    long countByUserAndIsCheckedFalse(User user);
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/dto/response/GetAlarmUnreadResponse.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/dto/response/GetAlarmUnreadResponse.java
@@ -1,0 +1,13 @@
+package ku_rum.backend.domain.alarm.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record GetAlarmUnreadResponse(boolean hasUnread, int count) {
+    public static GetAlarmUnreadResponse of(long unCheckedAlarm, long unCheckAnnouncementCount) {
+        return GetAlarmUnreadResponse.builder()
+                .hasUnread(unCheckedAlarm + unCheckAnnouncementCount > 0)
+                .count((int) (unCheckedAlarm + unCheckAnnouncementCount))
+                .build();
+    }
+}

--- a/src/main/java/ku_rum/backend/domain/alarm/presentation/AlarmController.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/presentation/AlarmController.java
@@ -5,6 +5,7 @@ import ku_rum.backend.domain.alarm.application.AlarmService;
 import ku_rum.backend.domain.alarm.dto.request.PatchAlarmRequest;
 import ku_rum.backend.domain.alarm.dto.response.AlarmPaginationRequest;
 import ku_rum.backend.domain.alarm.dto.response.GetAlarmResponse;
+import ku_rum.backend.domain.alarm.dto.response.GetAlarmUnreadResponse;
 import ku_rum.backend.domain.alarm.dto.response.PatchAlarmResponse;
 import ku_rum.backend.global.security.CustomUserDetails;
 import ku_rum.backend.global.support.response.BaseResponse;
@@ -32,11 +33,18 @@ public class AlarmController {
         return BaseResponse.ok(response);
     }
 
-    @PatchMapping()
+    @PatchMapping
     public BaseResponse<PatchAlarmResponse> patchAlarm(
             @RequestBody PatchAlarmRequest request,
             @AuthenticationPrincipal final CustomUserDetails userDetails) {
         PatchAlarmResponse response = alarmService.patchUserAlarm(userDetails, request);
+        return BaseResponse.ok(response);
+    }
+
+    @GetMapping("/unread")
+    public BaseResponse<GetAlarmUnreadResponse> getUnreadAlarm(
+            @AuthenticationPrincipal final CustomUserDetails userDetails) {
+        GetAlarmUnreadResponse response = alarmService.getAlarmUnreadResponse(userDetails);
         return BaseResponse.ok(response);
     }
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/presentation/AlarmController.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/presentation/AlarmController.java
@@ -7,6 +7,7 @@ import ku_rum.backend.domain.alarm.dto.response.AlarmPaginationRequest;
 import ku_rum.backend.domain.alarm.dto.response.GetAlarmResponse;
 import ku_rum.backend.domain.alarm.dto.response.GetAlarmUnreadResponse;
 import ku_rum.backend.domain.alarm.dto.response.PatchAlarmResponse;
+import ku_rum.backend.domain.notice.application.NoticeAlarmService;
 import ku_rum.backend.global.security.CustomUserDetails;
 import ku_rum.backend.global.support.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AlarmController {
 
     private final AlarmService alarmService;
+    private final NoticeAlarmService noticeAlarmService;
 
     @GetMapping
     public BaseResponse<GetAlarmResponse> getAlarm(
@@ -46,5 +48,11 @@ public class AlarmController {
             @AuthenticationPrincipal final CustomUserDetails userDetails) {
         GetAlarmUnreadResponse response = alarmService.getAlarmUnreadResponse(userDetails);
         return BaseResponse.ok(response);
+    }
+
+    @GetMapping("/test")
+    public BaseResponse<Void> test() {
+        noticeAlarmService.checkNewAlarm();
+        return BaseResponse.ok();
     }
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/presentation/AlarmController.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/presentation/AlarmController.java
@@ -7,7 +7,6 @@ import ku_rum.backend.domain.alarm.dto.response.AlarmPaginationRequest;
 import ku_rum.backend.domain.alarm.dto.response.GetAlarmResponse;
 import ku_rum.backend.domain.alarm.dto.response.GetAlarmUnreadResponse;
 import ku_rum.backend.domain.alarm.dto.response.PatchAlarmResponse;
-import ku_rum.backend.domain.notice.application.NoticeAlarmService;
 import ku_rum.backend.global.security.CustomUserDetails;
 import ku_rum.backend.global.support.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +24,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class AlarmController {
 
     private final AlarmService alarmService;
-    private final NoticeAlarmService noticeAlarmService;
 
     @GetMapping
     public BaseResponse<GetAlarmResponse> getAlarm(
@@ -48,11 +46,5 @@ public class AlarmController {
             @AuthenticationPrincipal final CustomUserDetails userDetails) {
         GetAlarmUnreadResponse response = alarmService.getAlarmUnreadResponse(userDetails);
         return BaseResponse.ok(response);
-    }
-
-    @GetMapping("/test")
-    public BaseResponse<Void> test() {
-        noticeAlarmService.checkNewAlarm();
-        return BaseResponse.ok();
     }
 }

--- a/src/main/java/ku_rum/backend/domain/notice/application/NoticeAlarmService.java
+++ b/src/main/java/ku_rum/backend/domain/notice/application/NoticeAlarmService.java
@@ -10,9 +10,11 @@ import ku_rum.backend.domain.notice.domain.PublishStatus;
 import ku_rum.backend.domain.notice.domain.SearchKeyword;
 import ku_rum.backend.domain.notice.domain.repository.NoticeRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NoticeAlarmService {
@@ -28,6 +30,7 @@ public class NoticeAlarmService {
         LocalDateTime sinceTime = LocalDateTime.now().minusHours(PAST_HOUR);
         List<Notice> notice = noticeRepository.findByPublishStatusAndPubDateAfter(
                 PublishStatus.SUCCESS_CRAWLING, sinceTime);
+        log.info("생성된 알림 조회 {}", notice.size());
         if (notice.isEmpty()) {
             return;
         }

--- a/src/main/java/ku_rum/backend/domain/notice/domain/Notice.java
+++ b/src/main/java/ku_rum/backend/domain/notice/domain/Notice.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,7 +33,7 @@ public class Notice {
 
     private String link;
 
-    private String pubDate;
+    private LocalDateTime pubDate;
 
     private String author;
 

--- a/src/main/java/ku_rum/backend/domain/notice/domain/SearchKeyword.java
+++ b/src/main/java/ku_rum/backend/domain/notice/domain/SearchKeyword.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import ku_rum.backend.domain.user.domain.User;
+import ku_rum.backend.global.support.type.BaseEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class SearchKeyword {
+public class SearchKeyword extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/ku_rum/backend/domain/notice/dto/response/NoticeResponse.java
+++ b/src/main/java/ku_rum/backend/domain/notice/dto/response/NoticeResponse.java
@@ -1,6 +1,7 @@
 package ku_rum.backend.domain.notice.dto.response;
 
 
+import java.time.LocalDateTime;
 import ku_rum.backend.domain.notice.domain.Notice;
 
 public record NoticeResponse(
@@ -9,7 +10,7 @@ public record NoticeResponse(
         String categoryName,
         String title,
         String link,
-        String pubDate,
+        LocalDateTime pubDate,
         String author,
         String description
 ) {

--- a/src/test/java/ku_rum/backend/domain/alarm/presentation/AlarmControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/alarm/presentation/AlarmControllerTest.java
@@ -24,6 +24,7 @@ import ku_rum.backend.domain.alarm.dto.request.PatchAlarmRequest;
 import ku_rum.backend.domain.alarm.dto.response.AlarmPaginationRequest;
 import ku_rum.backend.domain.alarm.dto.response.GetAlarmDto;
 import ku_rum.backend.domain.alarm.dto.response.GetAlarmResponse;
+import ku_rum.backend.domain.alarm.dto.response.GetAlarmUnreadResponse;
 import ku_rum.backend.domain.alarm.dto.response.PatchAlarmResponse;
 import ku_rum.backend.global.domain.repository.ApiLogRepository;
 import ku_rum.backend.global.security.JwtTokenAuthenticationFilter;
@@ -145,6 +146,43 @@ public class AlarmControllerTest extends RestDocsTestSupport {
                                         fieldWithPath("data.alarmType").description("알림 타입"),
                                         fieldWithPath("data.message").description("알림 메세지"),
                                         fieldWithPath("data.dataId").description("알림 데이터 ID")
+                                )
+                                .build()
+                )));
+    }
+
+    @DisplayName("안읽은 알림 갯수를 조회한다")
+    @Test
+    void getUnreadAlarmsCount() throws Exception {
+
+        // given
+        GetAlarmUnreadResponse response = GetAlarmUnreadResponse.of(1, 2);
+
+        AlarmPaginationRequest request = new AlarmPaginationRequest("12", 1);
+        given(alarmService.getAlarmUnreadResponse(any()))
+                .willReturn(response);
+
+        // when
+        mockMvc.perform(get("/api/v1/alarm/unread")
+                        .header("Authorization", "Bearer test-access-token"))
+                // then
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.hasUnread").value(true))
+                .andExpect(jsonPath("$.data.count").value(3))
+                .andDo(restDocs.document(resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("알림 조회 API")
+                                .description("안읽은 알림 갯수를 조회한다")
+                                .requestHeaders(
+                                        headerWithName("Authorization").description("발급 받은 액세스 토큰입니다.")
+                                )
+                                .responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("응답 상태"),
+                                        fieldWithPath("message").description("응답 메시지"),
+                                        fieldWithPath("data.hasUnread").description("안읽은 알람 유무"),
+                                        fieldWithPath("data.count").description("안읽은 알람 갯수")
                                 )
                                 .build()
                 )));

--- a/src/test/java/ku_rum/backend/domain/notice/presentation/NoticeControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/notice/presentation/NoticeControllerTest.java
@@ -1,6 +1,21 @@
 package ku_rum.backend.domain.notice.presentation;
 
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import java.time.LocalDateTime;
+import java.util.List;
 import ku_rum.backend.config.RestDocsTestSupport;
 import ku_rum.backend.domain.notice.application.NoticeService;
 import ku_rum.backend.domain.notice.dto.response.NoticeDetailResponse;
@@ -18,21 +33,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.ActiveProfiles;
-
-import java.util.List;
-
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(NoticeController.class)
 @ActiveProfiles("test")
@@ -57,9 +57,10 @@ public class NoticeControllerTest extends RestDocsTestSupport {
         Long categoryId = Long.valueOf(234);
         Pageable pageable = PageRequest.of(0, 2);
 
+        LocalDateTime localDateTime = LocalDateTime.now();
         List<NoticeResponse> noticeList = List.of(
-                new NoticeResponse(1L, categoryId, "학사", "공지 제목 1", "https://link1.com", "2024-01-01", "관리자", "설명1"),
-                new NoticeResponse(2L, categoryId, "학사", "공지 제목 2", "https://link2.com", "2024-01-02", "관리자", "설명2")
+                new NoticeResponse(1L, categoryId, "학사", "공지 제목 1", "https://link1.com", localDateTime, "관리자", "설명1"),
+                new NoticeResponse(2L, categoryId, "학사", "공지 제목 2", "https://link2.com", localDateTime, "관리자", "설명2")
         );
 
         Page<NoticeResponse> page = new PageImpl<>(noticeList, pageable, noticeList.size());
@@ -146,10 +147,12 @@ public class NoticeControllerTest extends RestDocsTestSupport {
     @Test
     void getPopularNotices() throws Exception {
         // given
+        LocalDateTime localDateTime = LocalDateTime.now();
+
         List<NoticeResponse> fakeResponse = List.of(
-                new NoticeResponse(1L, 1L, "학사", "공지 제목 1", "https://link1.com", "2024-01-01", "관리자", "설명1"),
-                new NoticeResponse(2L, 2L, "학사", "공지 제목 2", "https://link2.com", "2024-01-02", "관리자", "설명2"),
-                new NoticeResponse(3L, 3L, "장학", "공지 제목 3", "https://link3.com", "2024-01-03", "관리자", "설명3")
+                new NoticeResponse(1L, 1L, "학사", "공지 제목 1", "https://link1.com", localDateTime, "관리자", "설명1"),
+                new NoticeResponse(2L, 2L, "학사", "공지 제목 2", "https://link2.com", localDateTime, "관리자", "설명2"),
+                new NoticeResponse(3L, 3L, "장학", "공지 제목 3", "https://link3.com", localDateTime, "관리자", "설명3")
         );
 
         given(noticeService.findPopularNotice())
@@ -192,10 +195,11 @@ public class NoticeControllerTest extends RestDocsTestSupport {
     @Test
     void getPrimaryNotices() throws Exception {
         // given
+        LocalDateTime localDateTime = LocalDateTime.now();
         List<NoticeResponse> fakeResponse = List.of(
-                new NoticeResponse(1L, 1L, "학사", "중요 공지 제목 1", "https://link1.com", "2024-01-01", "관리자", "설명1"),
-                new NoticeResponse(2L, 2L, "학사", "중요 공지 제목 2", "https://link2.com", "2024-01-02", "관리자", "설명2"),
-                new NoticeResponse(3L, 3L, "장학", "중요 공지 제목 3", "https://link3.com", "2024-01-03", "관리자", "설명3")
+                new NoticeResponse(1L, 1L, "학사", "중요 공지 제목 1", "https://link1.com", localDateTime, "관리자", "설명1"),
+                new NoticeResponse(2L, 2L, "학사", "중요 공지 제목 2", "https://link2.com", localDateTime, "관리자", "설명2"),
+                new NoticeResponse(3L, 3L, "장학", "중요 공지 제목 3", "https://link3.com", localDateTime, "관리자", "설명3")
         );
 
         // 현재 컨트롤러가 noticeService.findPopularNotice()를 호출하고 있으므로 그대로 사용
@@ -239,12 +243,14 @@ public class NoticeControllerTest extends RestDocsTestSupport {
     @Test
     void searchNoticesByKeyword() throws Exception {
         // given
+        LocalDateTime localDateTime = LocalDateTime.now();
         String keyword = "입학식";
         Pageable pageable = PageRequest.of(0, 2);
 
         List<NoticeResponse> noticeList = List.of(
-                new NoticeResponse(1L, 234L, "학사", "입학식 안내 공지", "https://link1.com", "2024-03-01", "관리자", "입학식 관련 설명"),
-                new NoticeResponse(2L, 234L, "학사", "입학식 장소 변경 안내", "https://link2.com", "2024-03-02", "관리자", "장소 변경 설명")
+                new NoticeResponse(1L, 234L, "학사", "입학식 안내 공지", "https://link1.com", localDateTime, "관리자", "입학식 관련 설명"),
+                new NoticeResponse(2L, 234L, "학사", "입학식 장소 변경 안내", "https://link2.com", localDateTime, "관리자",
+                        "장소 변경 설명")
         );
 
         Page<NoticeResponse> page = new PageImpl<>(noticeList, pageable, noticeList.size());


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closes #349 #348 

## 📝작업 내용
- [x] 알림 확인 API
- [x] 알림 커서 페이지네이셔 버그 수정
- [x] 공지 알림 로직 버그 수정

## 작업 상세 내용
- 제목과 같습니다
- 공지사항 데이터 관련 람다 수정했습니다

## 💬리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 읽지 않은 알림·공지의 총 개수(유무 및 합계)를 반환하는 확인용 엔드포인트가 추가되었습니다.

* **개선 사항**
  * 위치 공유 알림 메시지에 발신자의 닉네임이 명확히 표시됩니다.
  * 공지사항의 게시일 타입이 개선되어 날짜/시간 처리가 정확해졌습니다.
  * 알림 목록의 커서 기반 페이징 로직이 개선되어 더 안정적인 이어보기(페이징) 경험을 제공합니다.

* **테스트**
  * 읽지 않은 알림 카운트와 날짜 타입 변경을 반영한 테스트 및 문서화가 추가/업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->