### PR TITLE
[Feat] 푸시 알림 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,16 @@ jobs:
           --health-timeout=5s
           --health-retries=3
     steps:
-      - uses: actions/checkout@v4
-
       - name: MySQL 접속해서 공간 함수를 테스트 한다
         run: |
           sudo apt-get install -y mysql-client
           mysql -h 127.0.0.1 -P 3306 -u root -ptestdb -e "SELECT ST_Contains(ST_GeomFromText('POLYGON((0 0,0 10,10 10,10 0,0 0))'), ST_GeomFromText('POINT(5 5)'));" testdb
+
+      - name: CheckOut
+        uses: actions/checkout@v4
+        with:
+          token: ${{secrets.CONFIG_SUBMODULE_TOKEN}}
+          submodules: true
 
       - name: JDK 17 를 준비한다.
         uses: actions/setup-java@v4

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,10 @@ src/main/resources/static/docs/
 
 ### ngrinder ###
 ngrinder-controller/
+
+### FCM Configuration
+/src/main/resources/firebase
+
+### DB import
+/scripts/import_db.sh
+/scripts/*.sql

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ logs/
 src/main/resources/application-prod.yml
 src/main/resources/application-local.yml
 src/main/resources/application-test.yml
-src/main/resources/kuroom-90fb5-firebase-adminsdk-fbsvc-f264f66c64.json
+firebase-adminsdk.json
 src/main/resources/firebase-key.json
 logs/*
 

--- a/build.gradle
+++ b/build.gradle
@@ -194,6 +194,9 @@ dependencies {
     // Test Container
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:mysql'
+
+    // FCM
+    implementation 'com.google.firebase:firebase-admin:9.7.0'
 }
 
 

--- a/src/main/java/ku_rum/backend/domain/alarm/application/AlarmMessageHandler.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/application/AlarmMessageHandler.java
@@ -3,10 +3,16 @@ package ku_rum.backend.domain.alarm.application;
 import ku_rum.backend.domain.alarm.domain.Alarm;
 import ku_rum.backend.domain.alarm.domain.AlarmType;
 import ku_rum.backend.domain.alarm.domain.Announcement;
+import ku_rum.backend.domain.alarm.dto.FcmDirectDto;
+import ku_rum.backend.domain.alarm.dto.FcmTopicDto;
 import ku_rum.backend.domain.user.domain.User;
 
 public interface AlarmMessageHandler {
     Alarm create(AlarmType alarmType, Object object, User user);
 
     Announcement create(AlarmType alarmType, Object object);
+
+    FcmTopicDto getFcmTopicDto(Object object);
+
+    FcmDirectDto getFcmDirectDto(Object object, User user);
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/application/AlarmService.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/application/AlarmService.java
@@ -15,6 +15,8 @@ import ku_rum.backend.domain.alarm.domain.repository.AlarmRepository;
 import ku_rum.backend.domain.alarm.domain.repository.AnnouncementRepository;
 import ku_rum.backend.domain.alarm.domain.repository.UserAnnouncementRepository;
 import ku_rum.backend.domain.alarm.dto.AlarmCursorDto;
+import ku_rum.backend.domain.alarm.dto.FcmDirectDto;
+import ku_rum.backend.domain.alarm.dto.FcmTopicDto;
 import ku_rum.backend.domain.alarm.dto.request.PatchAlarmRequest;
 import ku_rum.backend.domain.alarm.dto.response.AlarmPaginationRequest;
 import ku_rum.backend.domain.alarm.dto.response.GetAlarmDto;
@@ -53,6 +55,9 @@ public class AlarmService {
         }
 
         createAndSaveAlarm(alarmMessageHandler, alarmType, object, user);
+
+        FcmDirectDto fcmDirectDto = alarmMessageHandler.getFcmDirectDto(object, user);
+        fcmService.sendToUsers(fcmDirectDto);
     }
 
     @Transactional
@@ -70,10 +75,14 @@ public class AlarmService {
         }
 
         createAndSaveAnnouncement(alarmMessageHandler, alarmType, object);
+
+        FcmTopicDto fcmTopicDto = alarmMessageHandler.getFcmTopicDto(object);
+        fcmService.sendToTopic(fcmTopicDto);
     }
 
     @Transactional
-    public void createAndSaveAnnouncement(AlarmMessageHandler alarmMessageHandler, AlarmType alarmType, Object object) {
+    public void createAndSaveAnnouncement(AlarmMessageHandler alarmMessageHandler,
+                                          AlarmType alarmType, Object object) {
         Announcement announcement = alarmMessageHandler.create(alarmType, object);
         Announcement saveAnnouncement = announcementRepository.save(announcement);
         saveUserAnnouncement(saveAnnouncement);
@@ -145,7 +154,7 @@ public class AlarmService {
         return PatchAlarmResponse.from(userAnnouncement);
     }
 
-    private void saveUserAnnouncement(Announcement announcement) {
+    private List<UserAnnouncement> saveUserAnnouncement(Announcement announcement) {
         List<UserAnnouncement> userAnnouncements = userRepository.findAll().stream()
                 .map(user -> UserAnnouncement.builder()
                         .isChecked(false)
@@ -153,7 +162,7 @@ public class AlarmService {
                         .announcement(announcement)
                         .build())
                 .toList();
-        userAnnouncementRepository.saveAll(userAnnouncements);
+        return userAnnouncementRepository.saveAll(userAnnouncements);
     }
 
     private Alarm findAlarmById(Long alarmId) {

--- a/src/main/java/ku_rum/backend/domain/alarm/application/AlarmService.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/application/AlarmService.java
@@ -44,26 +44,36 @@ public class AlarmService {
     private final UserAnnouncementRepository userAnnouncementRepository;
     private final UserRepository userRepository;
     private final UserService userService;
+    private final FcmService fcmService;
 
-    @Transactional
     public void notifyAlarm(AlarmType alarmType, Object object, User user) {
         AlarmMessageHandler alarmMessageHandler = alarmMessageHandlers.get(alarmType);
         if (alarmMessageHandler == null) {
             throw new IllegalArgumentException("지원하지 않는 알림 타입입니다: " + alarmType);
         }
 
+        createAndSaveAlarm(alarmMessageHandler, alarmType, object, user);
+    }
+
+    @Transactional
+    public void createAndSaveAlarm(AlarmMessageHandler alarmMessageHandler, AlarmType alarmType, Object object,
+                                   User user) {
         Alarm alarm = alarmMessageHandler.create(alarmType, object, user);
 
         alarmRepository.save(alarm);
     }
 
-    @Transactional
     public void notifyAlarm(AlarmType alarmType, Object object) {
         AlarmMessageHandler alarmMessageHandler = alarmMessageHandlers.get(alarmType);
         if (alarmMessageHandler == null) {
             throw new IllegalArgumentException("지원하지 않는 알림 타입입니다: " + alarmType);
         }
 
+        createAndSaveAnnouncement(alarmMessageHandler, alarmType, object);
+    }
+
+    @Transactional
+    public void createAndSaveAnnouncement(AlarmMessageHandler alarmMessageHandler, AlarmType alarmType, Object object) {
         Announcement announcement = alarmMessageHandler.create(alarmType, object);
         Announcement saveAnnouncement = announcementRepository.save(announcement);
         saveUserAnnouncement(saveAnnouncement);

--- a/src/main/java/ku_rum/backend/domain/alarm/application/FcmService.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/application/FcmService.java
@@ -9,8 +9,8 @@ import com.google.firebase.messaging.MulticastMessage;
 import java.util.List;
 import java.util.Optional;
 import ku_rum.backend.domain.alarm.domain.repository.UserFcmTokenRepository;
-import ku_rum.backend.domain.alarm.dto.request.DirectNotificationRequest;
-import ku_rum.backend.domain.alarm.dto.request.TopicNotificationRequest;
+import ku_rum.backend.domain.alarm.dto.FcmDirectDto;
+import ku_rum.backend.domain.alarm.dto.FcmTopicDto;
 import ku_rum.backend.domain.user.application.UserQueryService;
 import ku_rum.backend.domain.user.application.UserService;
 import ku_rum.backend.domain.user.domain.User;
@@ -19,9 +19,11 @@ import ku_rum.backend.domain.user.dto.request.UserFcmRequest;
 import ku_rum.backend.domain.user.dto.response.UserFcmResponse;
 import ku_rum.backend.global.exception.global.GlobalException;
 import ku_rum.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class FcmService {
 
     private final FirebaseMessaging firebaseMessaging;
@@ -29,15 +31,7 @@ public class FcmService {
     private final UserQueryService userQueryService;
     private final UserService userService;
 
-    public FcmService(UserFcmTokenRepository userFcmTokenRepository,
-                      UserQueryService userQueryService, UserService userService) {
-        this.userFcmTokenRepository = userFcmTokenRepository;
-        this.userQueryService = userQueryService;
-        this.userService = userService;
-        this.firebaseMessaging = FirebaseMessaging.getInstance();
-    }
-
-    public void sendToUsers(DirectNotificationRequest request) {
+    public void sendToUsers(FcmDirectDto request) {
         List<User> users = request.userIds().stream()
                 .map(userQueryService::getUserById)
                 .toList();
@@ -61,7 +55,7 @@ public class FcmService {
 
     }
 
-    public void sendToTopic(TopicNotificationRequest request) {
+    public void sendToTopic(FcmTopicDto request) {
 
         Message message = Message.builder()
                 .setTopic(request.topic())

--- a/src/main/java/ku_rum/backend/domain/alarm/application/FcmService.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/application/FcmService.java
@@ -7,27 +7,33 @@ import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MulticastMessage;
 import java.util.List;
-import ku_rum.backend.domain.alarm.domain.UserFcmToken;
+import java.util.Optional;
 import ku_rum.backend.domain.alarm.domain.repository.UserFcmTokenRepository;
 import ku_rum.backend.domain.alarm.dto.request.DirectNotificationRequest;
 import ku_rum.backend.domain.alarm.dto.request.TopicNotificationRequest;
 import ku_rum.backend.domain.user.application.UserQueryService;
+import ku_rum.backend.domain.user.application.UserService;
 import ku_rum.backend.domain.user.domain.User;
+import ku_rum.backend.domain.user.domain.UserFcmToken;
+import ku_rum.backend.domain.user.dto.request.UserFcmRequest;
+import ku_rum.backend.domain.user.dto.response.UserFcmResponse;
 import ku_rum.backend.global.exception.global.GlobalException;
+import ku_rum.backend.global.security.CustomUserDetails;
 import org.springframework.stereotype.Service;
 
 @Service
-
 public class FcmService {
 
     private final FirebaseMessaging firebaseMessaging;
     private final UserFcmTokenRepository userFcmTokenRepository;
     private final UserQueryService userQueryService;
+    private final UserService userService;
 
     public FcmService(UserFcmTokenRepository userFcmTokenRepository,
-                      UserQueryService userQueryService) {
+                      UserQueryService userQueryService, UserService userService) {
         this.userFcmTokenRepository = userFcmTokenRepository;
         this.userQueryService = userQueryService;
+        this.userService = userService;
         this.firebaseMessaging = FirebaseMessaging.getInstance();
     }
 
@@ -68,5 +74,25 @@ public class FcmService {
         } catch (FirebaseMessagingException e) {
             throw new GlobalException(FCM_SEND_ERROR);
         }
+    }
+
+    public UserFcmResponse createFcmToken(CustomUserDetails userDetails, UserFcmRequest request) {
+        User user = userService.getUser();
+        Optional<UserFcmToken> fcmTokenOptional = userFcmTokenRepository.findByUser(user);
+
+        UserFcmToken userFcmToken = UserFcmToken.builder()
+                .token(request.token())
+                .user(user)
+                .deviceType(request.deviceType())
+                .build();
+
+        if (fcmTokenOptional.isPresent()) {
+            UserFcmToken findUserFcmToken = fcmTokenOptional.get();
+            findUserFcmToken.update(userFcmToken);
+            return UserFcmResponse.from(findUserFcmToken);
+        }
+
+        UserFcmToken saveUserFcmToken = userFcmTokenRepository.save(userFcmToken);
+        return UserFcmResponse.from(saveUserFcmToken);
     }
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/application/FcmService.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/application/FcmService.java
@@ -1,0 +1,72 @@
+package ku_rum.backend.domain.alarm.application;
+
+import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.FCM_SEND_ERROR;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MulticastMessage;
+import java.util.List;
+import ku_rum.backend.domain.alarm.domain.UserFcmToken;
+import ku_rum.backend.domain.alarm.domain.repository.UserFcmTokenRepository;
+import ku_rum.backend.domain.alarm.dto.request.DirectNotificationRequest;
+import ku_rum.backend.domain.alarm.dto.request.TopicNotificationRequest;
+import ku_rum.backend.domain.user.application.UserQueryService;
+import ku_rum.backend.domain.user.domain.User;
+import ku_rum.backend.global.exception.global.GlobalException;
+import org.springframework.stereotype.Service;
+
+@Service
+
+public class FcmService {
+
+    private final FirebaseMessaging firebaseMessaging;
+    private final UserFcmTokenRepository userFcmTokenRepository;
+    private final UserQueryService userQueryService;
+
+    public FcmService(UserFcmTokenRepository userFcmTokenRepository,
+                      UserQueryService userQueryService) {
+        this.userFcmTokenRepository = userFcmTokenRepository;
+        this.userQueryService = userQueryService;
+        this.firebaseMessaging = FirebaseMessaging.getInstance();
+    }
+
+    public void sendToUsers(DirectNotificationRequest request) {
+        List<User> users = request.userIds().stream()
+                .map(userQueryService::getUserById)
+                .toList();
+
+        List<UserFcmToken> userFcmTokens = userFcmTokenRepository.findByUserIn(users);
+        List<String> tokens = userFcmTokens.stream()
+                .map(UserFcmToken::getToken)
+                .toList();
+
+        MulticastMessage message = MulticastMessage.builder()
+                .addAllTokens(tokens)
+                .putData("title", request.title())
+                .putData("body", request.body())
+                .build();
+
+        try {
+            firebaseMessaging.sendMulticast(message);
+        } catch (FirebaseMessagingException e) {
+            throw new GlobalException(FCM_SEND_ERROR);
+        }
+
+    }
+
+    public void sendToTopic(TopicNotificationRequest request) {
+
+        Message message = Message.builder()
+                .setTopic(request.topic())
+                .putData("title", request.title())
+                .putData("body", request.body())
+                .build();
+
+        try {
+            firebaseMessaging.send(message);
+        } catch (FirebaseMessagingException e) {
+            throw new GlobalException(FCM_SEND_ERROR);
+        }
+    }
+}

--- a/src/main/java/ku_rum/backend/domain/alarm/application/FriendPlaceSharingHandler.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/application/FriendPlaceSharingHandler.java
@@ -1,8 +1,13 @@
 package ku_rum.backend.domain.alarm.application;
 
+import static ku_rum.backend.domain.alarm.util.FcmUtil.MESSAGE_TITLE;
+
+import java.util.List;
 import ku_rum.backend.domain.alarm.domain.Alarm;
 import ku_rum.backend.domain.alarm.domain.AlarmType;
 import ku_rum.backend.domain.alarm.domain.Announcement;
+import ku_rum.backend.domain.alarm.dto.FcmDirectDto;
+import ku_rum.backend.domain.alarm.dto.FcmTopicDto;
 import ku_rum.backend.domain.place.dto.UserPlaceAlarmDto;
 import ku_rum.backend.domain.user.domain.User;
 import org.springframework.stereotype.Component;
@@ -12,10 +17,9 @@ public class FriendPlaceSharingHandler implements AlarmMessageHandler {
     @Override
     public Alarm create(AlarmType alarmType, Object object, User user) {
         UserPlaceAlarmDto userPlaceAlarmDto = (UserPlaceAlarmDto) object;
-        String message = String.format("%s 님이 위치를 공유했어요. 친구 위치를 확인해보세요.", userPlaceAlarmDto.user().getNickname());
         return Alarm.builder()
                 .alarmType(alarmType)
-                .message(message)
+                .message(getMessage(object))
                 .isChecked(false)
                 .dataId(String.valueOf(userPlaceAlarmDto.user()))
                 .user(user)
@@ -25,5 +29,24 @@ public class FriendPlaceSharingHandler implements AlarmMessageHandler {
     @Override
     public Announcement create(AlarmType alarmType, Object object) {
         return null;
+    }
+
+    @Override
+    public FcmTopicDto getFcmTopicDto(Object object) {
+        return null;
+    }
+
+    @Override
+    public FcmDirectDto getFcmDirectDto(Object object, User user) {
+        return FcmDirectDto.builder()
+                .title(MESSAGE_TITLE)
+                .body(getMessage(object))
+                .userIds(List.of(user.getId()))
+                .build();
+    }
+
+    public String getMessage(Object object) {
+        UserPlaceAlarmDto userPlaceAlarmDto = (UserPlaceAlarmDto) object;
+        return String.format("%s 님이 위치를 공유했어요. 친구 위치를 확인해보세요.", userPlaceAlarmDto.user().getNickname());
     }
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/application/FriendRequestHandler.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/application/FriendRequestHandler.java
@@ -1,8 +1,13 @@
 package ku_rum.backend.domain.alarm.application;
 
+import static ku_rum.backend.domain.alarm.util.FcmUtil.MESSAGE_TITLE;
+
+import java.util.List;
 import ku_rum.backend.domain.alarm.domain.Alarm;
 import ku_rum.backend.domain.alarm.domain.AlarmType;
 import ku_rum.backend.domain.alarm.domain.Announcement;
+import ku_rum.backend.domain.alarm.dto.FcmDirectDto;
+import ku_rum.backend.domain.alarm.dto.FcmTopicDto;
 import ku_rum.backend.domain.user.domain.User;
 import org.springframework.stereotype.Component;
 
@@ -11,11 +16,10 @@ public class FriendRequestHandler implements AlarmMessageHandler {
     @Override
     public Alarm create(AlarmType alarmType, Object object, User user) {
         User friend = (User) object;
-        String message = String.format("%s 님이 친구 신청을 했어요. 친구 신청을 수락하시겠어요?", friend.getNickname());
 
         return Alarm.builder()
                 .alarmType(alarmType)
-                .message(message)
+                .message(getMessage(object))
                 .isChecked(false)
                 .dataId(String.valueOf(friend.getNickname()))
                 .user(user)
@@ -25,5 +29,24 @@ public class FriendRequestHandler implements AlarmMessageHandler {
     @Override
     public Announcement create(AlarmType alarmType, Object object) {
         return null;
+    }
+
+    @Override
+    public FcmTopicDto getFcmTopicDto(Object object) {
+        return null;
+    }
+
+    @Override
+    public FcmDirectDto getFcmDirectDto(Object object, User user) {
+        return FcmDirectDto.builder()
+                .title(MESSAGE_TITLE)
+                .body(getMessage(object))
+                .userIds(List.of(user.getId()))
+                .build();
+    }
+
+    public String getMessage(Object object) {
+        User friend = (User) object;
+        return String.format("%s 님이 친구 신청을 했어요. 친구 신청을 수락하시겠어요?", friend.getNickname());
     }
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/application/NewKeywordNoticeHandler.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/application/NewKeywordNoticeHandler.java
@@ -1,9 +1,14 @@
 package ku_rum.backend.domain.alarm.application;
 
+import static ku_rum.backend.domain.alarm.util.FcmUtil.MESSAGE_TITLE;
+
+import java.util.List;
 import java.util.Map.Entry;
 import ku_rum.backend.domain.alarm.domain.Alarm;
 import ku_rum.backend.domain.alarm.domain.AlarmType;
 import ku_rum.backend.domain.alarm.domain.Announcement;
+import ku_rum.backend.domain.alarm.dto.FcmDirectDto;
+import ku_rum.backend.domain.alarm.dto.FcmTopicDto;
 import ku_rum.backend.domain.notice.domain.Notice;
 import ku_rum.backend.domain.notice.domain.SearchKeyword;
 import ku_rum.backend.domain.user.domain.User;
@@ -15,8 +20,7 @@ public class NewKeywordNoticeHandler implements AlarmMessageHandler {
     @Override
     public Alarm create(AlarmType alarmType, Object payload, User user) {
         Entry<SearchKeyword, Notice> entry = (Entry<SearchKeyword, Notice>) payload;
-        String keyword = entry.getKey().getKeyword();
-        String message = String.format("%s에 대한 공지가 올라왔어요.", keyword);
+        String message = getMessage(payload);
 
         return Alarm.builder()
                 .alarmType(AlarmType.NEW_KEYWORD_NOTICE)
@@ -29,5 +33,26 @@ public class NewKeywordNoticeHandler implements AlarmMessageHandler {
     @Override
     public Announcement create(AlarmType alarmType, Object payload) {
         return null;
+    }
+
+    @Override
+    public FcmTopicDto getFcmTopicDto(Object object) {
+        return null;
+    }
+
+    @Override
+    public FcmDirectDto getFcmDirectDto(Object object, User user) {
+
+        return FcmDirectDto.builder()
+                .title(MESSAGE_TITLE)
+                .body(getMessage(object))
+                .userIds(List.of(user.getId()))
+                .build();
+    }
+
+    public String getMessage(Object object) {
+        Entry<SearchKeyword, Notice> entry = (Entry<SearchKeyword, Notice>) object;
+        String keyword = entry.getKey().getKeyword();
+        return String.format("%s에 대한 공지가 올라왔어요.", keyword);
     }
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/application/NewNoticeHandler.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/application/NewNoticeHandler.java
@@ -1,8 +1,13 @@
 package ku_rum.backend.domain.alarm.application;
 
+import static ku_rum.backend.domain.alarm.util.FcmUtil.MESSAGE_TITLE;
+
 import ku_rum.backend.domain.alarm.domain.Alarm;
 import ku_rum.backend.domain.alarm.domain.AlarmType;
 import ku_rum.backend.domain.alarm.domain.Announcement;
+import ku_rum.backend.domain.alarm.dto.FcmDirectDto;
+import ku_rum.backend.domain.alarm.dto.FcmTopicDto;
+import ku_rum.backend.domain.alarm.util.FcmUtil;
 import ku_rum.backend.domain.user.domain.User;
 import org.springframework.stereotype.Component;
 
@@ -16,11 +21,27 @@ public class NewNoticeHandler implements AlarmMessageHandler {
 
     @Override
     public Announcement create(AlarmType alarmType, Object object) {
-        String message = String.format("새로운 공지가 올라왔어요. 바로 확인해보세요!");
-
         return Announcement.builder()
                 .alarmType(AlarmType.NEW_NOTICE)
-                .message(message)
+                .message(getMessage())
                 .build();
+    }
+
+    @Override
+    public FcmTopicDto getFcmTopicDto(Object object) {
+        return FcmTopicDto.builder()
+                .title(MESSAGE_TITLE)
+                .body(getMessage())
+                .topic(FcmUtil.TOPIC_NAME)
+                .build();
+    }
+
+    @Override
+    public FcmDirectDto getFcmDirectDto(Object object, User user) {
+        return null;
+    }
+
+    public String getMessage() {
+        return "새로운 공지가 올라왔어요. 바로 확인해보세요!";
     }
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/application/RenewRankPlaceHandler.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/application/RenewRankPlaceHandler.java
@@ -1,8 +1,13 @@
 package ku_rum.backend.domain.alarm.application;
 
+import static ku_rum.backend.domain.alarm.util.FcmUtil.MESSAGE_TITLE;
+
+import java.util.List;
 import ku_rum.backend.domain.alarm.domain.Alarm;
 import ku_rum.backend.domain.alarm.domain.AlarmType;
 import ku_rum.backend.domain.alarm.domain.Announcement;
+import ku_rum.backend.domain.alarm.dto.FcmDirectDto;
+import ku_rum.backend.domain.alarm.dto.FcmTopicDto;
 import ku_rum.backend.domain.user.domain.User;
 import org.springframework.stereotype.Component;
 
@@ -10,11 +15,9 @@ import org.springframework.stereotype.Component;
 public class RenewRankPlaceHandler implements AlarmMessageHandler {
     @Override
     public Alarm create(AlarmType alarmType, Object object, User user) {
-        String message = String.format("내 장소 랭킹의 순위가 바뀌었어요!");
-
         return Alarm.builder()
                 .alarmType(AlarmType.RENEW_RANK_PLACE)
-                .message(message)
+                .message(getMessage())
                 .isChecked(false)
                 .user(user)
                 .build();
@@ -23,5 +26,23 @@ public class RenewRankPlaceHandler implements AlarmMessageHandler {
     @Override
     public Announcement create(AlarmType alarmType, Object object) {
         return null;
+    }
+
+    @Override
+    public FcmTopicDto getFcmTopicDto(Object object) {
+        return null;
+    }
+
+    @Override
+    public FcmDirectDto getFcmDirectDto(Object object, User user) {
+        return FcmDirectDto.builder()
+                .title(MESSAGE_TITLE)
+                .body(getMessage())
+                .userIds(List.of(user.getId()))
+                .build();
+    }
+
+    public String getMessage() {
+        return "내 장소 랭킹의 순위가 바뀌었어요!";
     }
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/application/RenewTopRankPlaceHandler.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/application/RenewTopRankPlaceHandler.java
@@ -1,8 +1,13 @@
 package ku_rum.backend.domain.alarm.application;
 
+import static ku_rum.backend.domain.alarm.util.FcmUtil.MESSAGE_TITLE;
+
+import java.util.List;
 import ku_rum.backend.domain.alarm.domain.Alarm;
 import ku_rum.backend.domain.alarm.domain.AlarmType;
 import ku_rum.backend.domain.alarm.domain.Announcement;
+import ku_rum.backend.domain.alarm.dto.FcmDirectDto;
+import ku_rum.backend.domain.alarm.dto.FcmTopicDto;
 import ku_rum.backend.domain.place.application.RankingChangeDto;
 import ku_rum.backend.domain.user.domain.User;
 import org.springframework.stereotype.Component;
@@ -12,13 +17,9 @@ public class RenewTopRankPlaceHandler implements AlarmMessageHandler {
 
     @Override
     public Alarm create(AlarmType alarmType, Object payload, User user) {
-        RankingChangeDto rankingChangeDto = (RankingChangeDto) payload;
-        String name = rankingChangeDto.placeRank().getPlace().getName();
-        String message = String.format("%s이 가장 많이 방문한 장소가 되었어요.", name);
-
         return Alarm.builder()
                 .alarmType(AlarmType.RENEW_TOP_RANK_PLACE)
-                .message(message)
+                .message(getMessage(payload))
                 .isChecked(false)
                 .user(user)
                 .build();
@@ -27,5 +28,25 @@ public class RenewTopRankPlaceHandler implements AlarmMessageHandler {
     @Override
     public Announcement create(AlarmType alarmType, Object object) {
         return null;
+    }
+
+    @Override
+    public FcmTopicDto getFcmTopicDto(Object object) {
+        return null;
+    }
+
+    @Override
+    public FcmDirectDto getFcmDirectDto(Object object, User user) {
+        return FcmDirectDto.builder()
+                .title(MESSAGE_TITLE)
+                .body(getMessage(object))
+                .userIds(List.of(user.getId()))
+                .build();
+    }
+
+    public String getMessage(Object payload) {
+        RankingChangeDto rankingChangeDto = (RankingChangeDto) payload;
+        String name = rankingChangeDto.placeRank().getPlace().getName();
+        return String.format("%s이 가장 많이 방문한 장소가 되었어요.", name);
     }
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/domain/UserFcmToken.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/domain/UserFcmToken.java
@@ -1,0 +1,35 @@
+package ku_rum.backend.domain.alarm.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import ku_rum.backend.domain.user.domain.User;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserFcmToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", unique = true)
+    private User user;
+}

--- a/src/main/java/ku_rum/backend/domain/alarm/domain/repository/UserFcmTokenRepository.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/domain/repository/UserFcmTokenRepository.java
@@ -2,14 +2,15 @@ package ku_rum.backend.domain.alarm.domain.repository;
 
 import java.util.Collection;
 import java.util.List;
-import ku_rum.backend.domain.alarm.domain.UserFcmToken;
+import java.util.Optional;
 import ku_rum.backend.domain.user.domain.User;
+import ku_rum.backend.domain.user.domain.UserFcmToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserFcmTokenRepository extends JpaRepository<UserFcmToken, Long> {
-    List<UserFcmToken> findByUser(User user);
+    Optional<UserFcmToken> findByUser(User user);
 
     List<UserFcmToken> findByUserIn(Collection<User> users);
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/domain/repository/UserFcmTokenRepository.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/domain/repository/UserFcmTokenRepository.java
@@ -1,0 +1,15 @@
+package ku_rum.backend.domain.alarm.domain.repository;
+
+import java.util.Collection;
+import java.util.List;
+import ku_rum.backend.domain.alarm.domain.UserFcmToken;
+import ku_rum.backend.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserFcmTokenRepository extends JpaRepository<UserFcmToken, Long> {
+    List<UserFcmToken> findByUser(User user);
+
+    List<UserFcmToken> findByUserIn(Collection<User> users);
+}

--- a/src/main/java/ku_rum/backend/domain/alarm/dto/FcmDirectDto.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/dto/FcmDirectDto.java
@@ -1,6 +1,8 @@
 package ku_rum.backend.domain.alarm.dto;
 
 import java.util.List;
+import lombok.Builder;
 
+@Builder
 public record FcmDirectDto(String title, String body, List<Long> userIds) {
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/dto/FcmDirectDto.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/dto/FcmDirectDto.java
@@ -1,0 +1,6 @@
+package ku_rum.backend.domain.alarm.dto;
+
+import java.util.List;
+
+public record FcmDirectDto(String title, String body, List<Long> userIds) {
+}

--- a/src/main/java/ku_rum/backend/domain/alarm/dto/FcmTopicDto.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/dto/FcmTopicDto.java
@@ -1,4 +1,7 @@
 package ku_rum.backend.domain.alarm.dto;
 
+import lombok.Builder;
+
+@Builder
 public record FcmTopicDto(String title, String body, String topic) {
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/dto/FcmTopicDto.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/dto/FcmTopicDto.java
@@ -1,0 +1,4 @@
+package ku_rum.backend.domain.alarm.dto;
+
+public record FcmTopicDto(String title, String body, String topic) {
+}

--- a/src/main/java/ku_rum/backend/domain/alarm/dto/request/DirectNotificationRequest.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/dto/request/DirectNotificationRequest.java
@@ -1,0 +1,6 @@
+package ku_rum.backend.domain.alarm.dto.request;
+
+import java.util.List;
+
+public record DirectNotificationRequest(List<Long> userIds, String title, String body) {
+}

--- a/src/main/java/ku_rum/backend/domain/alarm/dto/request/TopicNotificationRequest.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/dto/request/TopicNotificationRequest.java
@@ -1,0 +1,4 @@
+package ku_rum.backend.domain.alarm.dto.request;
+
+public record TopicNotificationRequest(String topic, String title, String body) {
+}

--- a/src/main/java/ku_rum/backend/domain/alarm/presentation/AlarmController.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/presentation/AlarmController.java
@@ -3,6 +3,8 @@ package ku_rum.backend.domain.alarm.presentation;
 import jakarta.validation.Valid;
 import ku_rum.backend.domain.alarm.application.AlarmService;
 import ku_rum.backend.domain.alarm.application.FcmService;
+import ku_rum.backend.domain.alarm.dto.FcmDirectDto;
+import ku_rum.backend.domain.alarm.dto.FcmTopicDto;
 import ku_rum.backend.domain.alarm.dto.request.DirectNotificationRequest;
 import ku_rum.backend.domain.alarm.dto.request.PatchAlarmRequest;
 import ku_rum.backend.domain.alarm.dto.request.TopicNotificationRequest;
@@ -48,13 +50,15 @@ public class AlarmController {
 
     @PostMapping("/direct")
     public BaseResponse<Void> sendFcmMessage(@RequestBody DirectNotificationRequest request) {
-        fcmService.sendToUsers(request);
+        FcmDirectDto fcmDirectDto = new FcmDirectDto(request.title(), request.body(), request.userIds());
+        fcmService.sendToUsers(fcmDirectDto);
         return BaseResponse.ok();
     }
 
     @PostMapping("/topic")
     public BaseResponse<Void> sendFcmMessage(@RequestBody TopicNotificationRequest request) {
-        fcmService.sendToTopic(request);
+        FcmTopicDto fcmDirectDto = new FcmTopicDto(request.title(), request.body(), request.topic());
+        fcmService.sendToTopic(fcmDirectDto);
         return BaseResponse.ok();
     }
 

--- a/src/main/java/ku_rum/backend/domain/alarm/presentation/AlarmController.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/presentation/AlarmController.java
@@ -46,13 +46,13 @@ public class AlarmController {
     }
 
     @PostMapping("/direct")
-    public BaseResponse<Void> sendToUsers(@RequestBody DirectNotificationRequest request) {
+    public BaseResponse<Void> sendFcmMessage(@RequestBody DirectNotificationRequest request) {
         fcmService.sendToUsers(request);
         return BaseResponse.ok();
     }
 
     @PostMapping("/topic")
-    public BaseResponse<Void> sendToTopic(@RequestBody TopicNotificationRequest request) {
+    public BaseResponse<Void> sendFcmMessage(@RequestBody TopicNotificationRequest request) {
         fcmService.sendToTopic(request);
         return BaseResponse.ok();
     }

--- a/src/main/java/ku_rum/backend/domain/alarm/presentation/AlarmController.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/presentation/AlarmController.java
@@ -2,7 +2,10 @@ package ku_rum.backend.domain.alarm.presentation;
 
 import jakarta.validation.Valid;
 import ku_rum.backend.domain.alarm.application.AlarmService;
+import ku_rum.backend.domain.alarm.application.FcmService;
+import ku_rum.backend.domain.alarm.dto.request.DirectNotificationRequest;
 import ku_rum.backend.domain.alarm.dto.request.PatchAlarmRequest;
+import ku_rum.backend.domain.alarm.dto.request.TopicNotificationRequest;
 import ku_rum.backend.domain.alarm.dto.response.AlarmPaginationRequest;
 import ku_rum.backend.domain.alarm.dto.response.GetAlarmResponse;
 import ku_rum.backend.domain.alarm.dto.response.PatchAlarmResponse;
@@ -13,6 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AlarmController {
 
     private final AlarmService alarmService;
+    private final FcmService fcmService;
 
     @GetMapping
     public BaseResponse<GetAlarmResponse> getAlarm(
@@ -38,5 +43,17 @@ public class AlarmController {
             @AuthenticationPrincipal final CustomUserDetails userDetails) {
         PatchAlarmResponse response = alarmService.patchUserAlarm(userDetails, request);
         return BaseResponse.ok(response);
+    }
+
+    @PostMapping("/direct")
+    public BaseResponse<Void> sendToUsers(@RequestBody DirectNotificationRequest request) {
+        fcmService.sendToUsers(request);
+        return BaseResponse.ok();
+    }
+
+    @PostMapping("/topic")
+    public BaseResponse<Void> sendToTopic(@RequestBody TopicNotificationRequest request) {
+        fcmService.sendToTopic(request);
+        return BaseResponse.ok();
     }
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/util/FcmUtil.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/util/FcmUtil.java
@@ -1,0 +1,11 @@
+package ku_rum.backend.domain.alarm.util;
+
+public class FcmUtil {
+
+    private FcmUtil() {
+    }
+
+    public static final String TOPIC_NAME = "dev";
+
+    public static final String MESSAGE_TITLE = "알림";
+}

--- a/src/main/java/ku_rum/backend/domain/user/domain/DeviceType.java
+++ b/src/main/java/ku_rum/backend/domain/user/domain/DeviceType.java
@@ -1,0 +1,5 @@
+package ku_rum.backend.domain.user.domain;
+
+public enum DeviceType {
+    IOS, ANDROID
+}

--- a/src/main/java/ku_rum/backend/domain/user/domain/UserFcmToken.java
+++ b/src/main/java/ku_rum/backend/domain/user/domain/UserFcmToken.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import ku_rum.backend.global.support.type.BaseEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,7 +22,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class UserFcmToken {
+public class UserFcmToken extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/ku_rum/backend/domain/user/domain/UserFcmToken.java
+++ b/src/main/java/ku_rum/backend/domain/user/domain/UserFcmToken.java
@@ -1,14 +1,15 @@
-package ku_rum.backend.domain.alarm.domain;
+package ku_rum.backend.domain.user.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
-import ku_rum.backend.domain.user.domain.User;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,4 +33,12 @@ public class UserFcmToken {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", unique = true)
     private User user;
+
+    @Enumerated(EnumType.STRING)
+    private DeviceType deviceType;
+
+    public void update(UserFcmToken userFcmToken) {
+        this.token = userFcmToken.getToken();
+        deviceType = userFcmToken.getDeviceType();
+    }
 }

--- a/src/main/java/ku_rum/backend/domain/user/dto/request/UserFcmRequest.java
+++ b/src/main/java/ku_rum/backend/domain/user/dto/request/UserFcmRequest.java
@@ -1,0 +1,6 @@
+package ku_rum.backend.domain.user.dto.request;
+
+import ku_rum.backend.domain.user.domain.DeviceType;
+
+public record UserFcmRequest(String token, DeviceType deviceType) {
+}

--- a/src/main/java/ku_rum/backend/domain/user/dto/response/UserFcmResponse.java
+++ b/src/main/java/ku_rum/backend/domain/user/dto/response/UserFcmResponse.java
@@ -1,0 +1,17 @@
+package ku_rum.backend.domain.user.dto.response;
+
+import ku_rum.backend.domain.user.domain.DeviceType;
+import ku_rum.backend.domain.user.domain.UserFcmToken;
+import lombok.Builder;
+
+@Builder
+public record UserFcmResponse(Long id, String token, DeviceType deviceType) {
+
+    public static UserFcmResponse from(UserFcmToken userFcmToken) {
+        return UserFcmResponse.builder()
+                .id(userFcmToken.getId())
+                .token(userFcmToken.getToken())
+                .deviceType(userFcmToken.getDeviceType())
+                .build();
+    }
+}

--- a/src/main/java/ku_rum/backend/domain/user/presentation/UserController.java
+++ b/src/main/java/ku_rum/backend/domain/user/presentation/UserController.java
@@ -1,15 +1,25 @@
 package ku_rum.backend.domain.user.presentation;
 
+import static ku_rum.backend.domain.user.domain.UserMessage.VALID_EMAIL_MESSAGE;
+import static ku_rum.backend.domain.user.domain.UserMessage.VALID_LOGINID_MESSAGE;
+import static ku_rum.backend.domain.user.domain.UserMessage.VALID_NICKNAME_MESSAGE;
+import static ku_rum.backend.domain.user.domain.UserMessage.VALID_STUDENTID_MESSAGE;
+
 import jakarta.validation.Valid;
+import ku_rum.backend.domain.alarm.application.FcmService;
 import ku_rum.backend.domain.auth.dto.response.AuthResponse;
 import ku_rum.backend.domain.common.mail.dto.request.EmailValidationRequest;
 import ku_rum.backend.domain.user.application.UserService;
 import ku_rum.backend.domain.user.application.UserValidator;
 import ku_rum.backend.domain.user.dto.request.SocialSignupRequest;
+import ku_rum.backend.domain.user.dto.request.UserFcmRequest;
 import ku_rum.backend.domain.user.dto.request.UserSaveRequest;
+import ku_rum.backend.domain.user.dto.response.UserFcmResponse;
 import ku_rum.backend.domain.user.dto.response.UserSaveResponse;
+import ku_rum.backend.global.security.CustomUserDetails;
 import ku_rum.backend.global.support.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,11 +28,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import static ku_rum.backend.domain.user.domain.UserMessage.VALID_EMAIL_MESSAGE;
-import static ku_rum.backend.domain.user.domain.UserMessage.VALID_LOGINID_MESSAGE;
-import static ku_rum.backend.domain.user.domain.UserMessage.VALID_NICKNAME_MESSAGE;
-import static ku_rum.backend.domain.user.domain.UserMessage.VALID_STUDENTID_MESSAGE;
-
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
@@ -30,9 +35,11 @@ import static ku_rum.backend.domain.user.domain.UserMessage.VALID_STUDENTID_MESS
 public class UserController {
     private final UserService userService;
     private final UserValidator userValidator;
+    private final FcmService fcmService;
 
     /**
      * 회원 가입 API
+     *
      * @param userSaveRequest
      * @return
      */
@@ -43,6 +50,7 @@ public class UserController {
 
     /**
      * 소셜 로그인 회원 가입 API (토큰 필요)
+     *
      * @return
      */
     @PostMapping("/social")
@@ -52,6 +60,7 @@ public class UserController {
 
     /**
      * 이메일 검증 API
+     *
      * @param emailValidationRequest
      * @return
      */
@@ -63,6 +72,7 @@ public class UserController {
 
     /**
      * 아이디 중복 확인 API
+     *
      * @param value
      * @return
      */
@@ -74,6 +84,7 @@ public class UserController {
 
     /**
      * 닉네임 중복 확인 API
+     *
      * @param value
      * @return
      */
@@ -85,6 +96,7 @@ public class UserController {
 
     /**
      * 학번 중복 확인 API
+     *
      * @param value
      * @return
      */
@@ -92,6 +104,13 @@ public class UserController {
     public BaseResponse<String> checkDuplicateStudentId(@RequestParam("value") final String value) {
         userValidator.validateDuplicateStudentId(value);
         return BaseResponse.ok(VALID_STUDENTID_MESSAGE.getMessage());
+    }
+
+    @PostMapping("/fcm")
+    public BaseResponse<UserFcmResponse> createFcmToken(@AuthenticationPrincipal final CustomUserDetails userDetails,
+                                                        @RequestBody UserFcmRequest request) {
+        UserFcmResponse response = fcmService.createFcmToken(userDetails, request);
+        return BaseResponse.ok(response);
     }
 }
 

--- a/src/main/java/ku_rum/backend/global/config/FirebaseConfig.java
+++ b/src/main/java/ku_rum/backend/global/config/FirebaseConfig.java
@@ -1,0 +1,37 @@
+package ku_rum.backend.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import java.io.IOException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+@Configuration
+public class FirebaseConfig {
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging() {
+
+        try {
+            Resource resource = new ClassPathResource("config/firebase-service.json");
+
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(resource.getInputStream()))
+                    .build();
+
+            if (!FirebaseApp.getApps().isEmpty()) {
+                throw new IllegalStateException("FCM 이미 설정 완료");
+            }
+
+            FirebaseApp firebaseApp = FirebaseApp.initializeApp(options);
+            return FirebaseMessaging.getInstance(firebaseApp);
+
+        } catch (IOException e) {
+            throw new IllegalStateException("FCM 설정 실패", e);
+        }
+    }
+}

--- a/src/main/java/ku_rum/backend/global/support/status/BaseExceptionResponseStatus.java
+++ b/src/main/java/ku_rum/backend/global/support/status/BaseExceptionResponseStatus.java
@@ -141,7 +141,8 @@ public enum BaseExceptionResponseStatus implements ResponseStatus {
     ALARM_NOT_FOUND(1400, HttpStatus.NOT_FOUND, "해당하는 알림이 없습니다."),
     UNAUTHORIZED_ALARM(1401, HttpStatus.UNAUTHORIZED, "권한이 없는 알람입니다."),
     UNAUTHORIZED_ANNOUNCEMENT(1402, HttpStatus.UNAUTHORIZED, "권한이 없는 공지 알람입니다."),
-    INVALID_CURSOR_FORMAT(1403, HttpStatus.BAD_REQUEST, "알림 커서가 올바르지 않습니다.");
+    INVALID_CURSOR_FORMAT(1403, HttpStatus.BAD_REQUEST, "알림 커서가 올바르지 않습니다."),
+    FCM_SEND_ERROR(1404, HttpStatus.BAD_REQUEST, "알림 전송중 문제가 발생했습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/test/java/ku_rum/backend/domain/alarm/presentation/AlarmControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/alarm/presentation/AlarmControllerTest.java
@@ -18,6 +18,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import ku_rum.backend.config.RestDocsTestSupport;
 import ku_rum.backend.domain.alarm.application.AlarmService;
+import ku_rum.backend.domain.alarm.application.FcmService;
 import ku_rum.backend.domain.alarm.domain.AlarmCategory;
 import ku_rum.backend.domain.alarm.domain.AlarmType;
 import ku_rum.backend.domain.alarm.dto.request.PatchAlarmRequest;
@@ -41,6 +42,9 @@ public class AlarmControllerTest extends RestDocsTestSupport {
 
     @MockBean
     AlarmService alarmService;
+
+    @MockBean
+    FcmService fcmService;
 
     @MockBean
     private ApiLogRepository apiLogRepository;

--- a/src/test/java/ku_rum/backend/domain/alarm/presentation/FcmAlarmControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/alarm/presentation/FcmAlarmControllerTest.java
@@ -1,0 +1,124 @@
+package ku_rum.backend.domain.alarm.presentation;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import java.util.List;
+import ku_rum.backend.config.RestDocsTestSupport;
+import ku_rum.backend.domain.alarm.application.AlarmService;
+import ku_rum.backend.domain.alarm.application.FcmService;
+import ku_rum.backend.domain.alarm.dto.request.DirectNotificationRequest;
+import ku_rum.backend.domain.alarm.dto.request.TopicNotificationRequest;
+import ku_rum.backend.global.domain.repository.ApiLogRepository;
+import ku_rum.backend.global.security.JwtTokenAuthenticationFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+
+@WebMvcTest(AlarmController.class)
+@ActiveProfiles("test")
+public class FcmAlarmControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    AlarmService alarmService;
+
+    @MockBean
+    FcmService fcmService;
+
+    @MockBean
+    private ApiLogRepository apiLogRepository;
+
+    @MockBean
+    private SecurityFilterChain securityFilterChain;
+
+    @MockBean
+    private JwtTokenAuthenticationFilter jwtTokenAuthenticationFilter;
+
+    @DisplayName("특정 사용자에게 푸시 알림을 보낸다")
+    @Test
+    void sendToUsers() throws Exception {
+
+        // given
+        DirectNotificationRequest request = new DirectNotificationRequest(List.of(1L), "알림 제목", "알림 내용");
+        doNothing().when(fcmService).sendToUsers(eq(request));
+
+        // when
+        mockMvc.perform(post("/api/v1/alarm/direct")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userIds": [1],
+                                  "title": "알림 제목",
+                                  "body": "알림 내용"
+                                }
+                                """))
+                // then
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("알림 FCM API")
+                                .description("특정 사용자에게 푸시 알림을 보낸다")
+                                .requestFields(
+                                        fieldWithPath("userIds").description("유저 ID"),
+                                        fieldWithPath("title").description("알림 제목"),
+                                        fieldWithPath("body").description("알림 내용")
+                                )
+                                .responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("응답 상태"),
+                                        fieldWithPath("message").description("응답 메시지")
+                                )
+                                .build()
+                )));
+    }
+
+    @DisplayName("모든 사용자에게 푸시 알림을 보낸다")
+    @Test
+    void sendToTopic() throws Exception {
+
+        // given
+        TopicNotificationRequest request = new TopicNotificationRequest("kuroom", "알림 제목", "알림 내용");
+        doNothing().when(fcmService).sendToTopic(eq(request));
+
+        // when
+        mockMvc.perform(post("/api/v1/alarm/topic")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "topic": "kuroom",
+                                  "title": "알림 제목",
+                                  "body": "알림 내용"
+                                }
+                                """))
+                // then
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("알림 FCM API")
+                                .description("모든 사용자에게 푸시 알림을 보낸다")
+                                .requestFields(
+                                        fieldWithPath("topic").description("토픽 (kuroom)"),
+                                        fieldWithPath("title").description("알림 제목"),
+                                        fieldWithPath("body").description("알림 내용")
+                                )
+                                .responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("응답 상태"),
+                                        fieldWithPath("message").description("응답 메시지")
+                                )
+                                .build()
+                )));
+    }
+}

--- a/src/test/java/ku_rum/backend/domain/alarm/presentation/FcmAlarmControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/alarm/presentation/FcmAlarmControllerTest.java
@@ -13,8 +13,8 @@ import java.util.List;
 import ku_rum.backend.config.RestDocsTestSupport;
 import ku_rum.backend.domain.alarm.application.AlarmService;
 import ku_rum.backend.domain.alarm.application.FcmService;
-import ku_rum.backend.domain.alarm.dto.request.DirectNotificationRequest;
-import ku_rum.backend.domain.alarm.dto.request.TopicNotificationRequest;
+import ku_rum.backend.domain.alarm.dto.FcmDirectDto;
+import ku_rum.backend.domain.alarm.dto.FcmTopicDto;
 import ku_rum.backend.global.domain.repository.ApiLogRepository;
 import ku_rum.backend.global.security.JwtTokenAuthenticationFilter;
 import org.junit.jupiter.api.DisplayName;
@@ -49,7 +49,7 @@ public class FcmAlarmControllerTest extends RestDocsTestSupport {
     void sendToUsers() throws Exception {
 
         // given
-        DirectNotificationRequest request = new DirectNotificationRequest(List.of(1L), "알림 제목", "알림 내용");
+        FcmDirectDto request = new FcmDirectDto("알림 제목", "알림 내용", List.of(1L));
         doNothing().when(fcmService).sendToUsers(eq(request));
 
         // when
@@ -88,7 +88,7 @@ public class FcmAlarmControllerTest extends RestDocsTestSupport {
     void sendToTopic() throws Exception {
 
         // given
-        TopicNotificationRequest request = new TopicNotificationRequest("kuroom", "알림 제목", "알림 내용");
+        FcmTopicDto request = new FcmTopicDto("알림 제목", "알림 내용", "kuroom");
         doNothing().when(fcmService).sendToTopic(eq(request));
 
         // when

--- a/src/test/java/ku_rum/backend/domain/user/presentation/UserFcmControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/user/presentation/UserFcmControllerTest.java
@@ -1,0 +1,105 @@
+package ku_rum.backend.domain.user.presentation;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import ku_rum.backend.config.RestDocsTestSupport;
+import ku_rum.backend.domain.alarm.application.AlarmService;
+import ku_rum.backend.domain.alarm.application.FcmService;
+import ku_rum.backend.domain.user.application.UserService;
+import ku_rum.backend.domain.user.application.UserValidator;
+import ku_rum.backend.domain.user.domain.DeviceType;
+import ku_rum.backend.domain.user.dto.request.UserFcmRequest;
+import ku_rum.backend.domain.user.dto.response.UserFcmResponse;
+import ku_rum.backend.global.domain.repository.ApiLogRepository;
+import ku_rum.backend.global.security.JwtTokenAuthenticationFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+
+@WebMvcTest(UserController.class)
+@ActiveProfiles("test")
+public class UserFcmControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    AlarmService alarmService;
+
+    @MockBean
+    UserService userService;
+
+    @MockBean
+    UserValidator userValidator;
+
+    @MockBean
+    FcmService fcmService;
+
+    @MockBean
+    ApiLogRepository apiLogRepository;
+
+    @MockBean
+    SecurityFilterChain securityFilterChain;
+
+    @MockBean
+    JwtTokenAuthenticationFilter jwtTokenAuthenticationFilter;
+
+    @DisplayName("사용자 fcm 토큰을 저장한다")
+    @Test
+    void sendToUsers() throws Exception {
+
+        // given
+        String token = "fcm 토큰";
+        DeviceType deviceType = DeviceType.ANDROID;
+        UserFcmRequest request = new UserFcmRequest(token, deviceType);
+        UserFcmResponse response = new UserFcmResponse(1L, token, deviceType);
+
+        when(fcmService.createFcmToken(any(), eq(request)))
+                .thenReturn(response);
+
+        // when
+        mockMvc.perform(post("/api/v1/users/fcm")
+                        .header("Authorization", "Bearer test-access-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "token": "fcm 토큰",
+                                  "deviceType": "ANDROID"
+                                }
+                                """))
+                // then
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("멤버 관련 API")
+                                .description("특정 사용자에게 푸시 알림을 보낸다")
+                                .requestHeaders(
+                                        headerWithName("Authorization").description("발급 받은 액세스 토큰입니다.")
+                                )
+                                .requestFields(
+                                        fieldWithPath("token").description("토큰"),
+                                        fieldWithPath("deviceType").description("기기 종류(ANDROID,IOS)")
+                                )
+                                .responseFields(
+                                        fieldWithPath("code").description("응답 코드"),
+                                        fieldWithPath("status").description("응답 상태"),
+                                        fieldWithPath("message").description("응답 메시지"),
+                                        fieldWithPath("data.id").description("id"),
+                                        fieldWithPath("data.token").description("토큰"),
+                                        fieldWithPath("data.deviceType").description("기기 종류")
+                                )
+                                .build()
+                )));
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closes #345


## 📝작업 내용
- [x] 푸시 알림 로직 추가
- [x] 테스트 푸시 알림 API 추가

## 작업 상세 내용
상세 내용을 입력해주세요.
- 푸시 알림 로직을 추가하였습니다
- AlarmMessageHandler에서 FcmDto를 공통적으로 생성하여 FcmService에게 푸시 처리를 위임합니다.
- 푸시 알림 처리는 기존 비즈니스 트랜잭션에서 분리하고 있습니다.

## 💬리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

새로운 알림 요구사항에 대해 유연하게 대처할 수 있는 구조를 만드는 중입니다.
하나의 로직으로 처리하고 싶지만, 트랜잭션이 전파되서 분리하는 방법으로 우회했습니다(최선일까요)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Firebase Cloud Messaging(FCM) 기반 푸시 알림 추가 — 개인/주제(토픽) 전송 지원
  * 사용자 FCM 토큰 등록·관리 API 추가

* **API 변경**
  * 직접 알림 전송: POST /api/v1/alarm/direct
  * 주제 알림 전송: POST /api/v1/alarm/topic
  * FCM 토큰 저장: POST /api/v1/users/fcm

* **테스트**
  * FCM 관련 컨트롤러 테스트 및 문서화 추가

* **기타**
  * 빌드/CI 및 .gitignore 정리 (FCM/스크립트 무시 항목 추가)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->