### PR TITLE
[Fix] 알림 비활성화/활성화 API 변경

### DIFF
--- a/src/main/java/ku_rum/backend/domain/alarm/application/AlarmService.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/application/AlarmService.java
@@ -1,10 +1,13 @@
 package ku_rum.backend.domain.alarm.application;
 
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import ku_rum.backend.domain.alarm.domain.Alarm;
 import ku_rum.backend.domain.alarm.domain.AlarmCategory;
@@ -143,22 +146,39 @@ public class AlarmService {
     @Transactional
     public PatchDisableAlarmResponse disableAlarm(CustomUserDetails userDetails, PatchDisableAlarmRequest request) {
         User user = userService.getUser();
-        AlarmType alarmType = request.alarmType();
-        Optional<UserDisabledAlarm> optional = userDisabledAlarmRepository.findByUserAndAlarmType(user,
-                alarmType);
+        List<AlarmType> alarmTypes = request.alarmTypes();
+        List<UserDisabledAlarm> existingDisabledAlarms = userDisabledAlarmRepository.findByUserAndAlarmTypeIn(user,
+                alarmTypes);
+        Set<AlarmType> existingAlarmTypes = existingDisabledAlarms.stream()
+                .map(UserDisabledAlarm::getAlarmType)
+                .collect(Collectors.toSet());
 
-        if (optional.isEmpty()) {
+        List<UserDisabledAlarm> toCreate = new ArrayList<>();
+        List<UserDisabledAlarm> toDelete = new ArrayList<>();
+
+        for (AlarmType alarmType : alarmTypes) {
+            if (existingAlarmTypes.contains(alarmType)) {
+                existingDisabledAlarms.stream()
+                        .filter(alarm -> alarm.getAlarmType().equals(alarmType))
+                        .findFirst()
+                        .ifPresent(toDelete::add);
+                continue;
+            }
             UserDisabledAlarm userDisabledAlarm = UserDisabledAlarm.builder()
                     .user(user)
                     .alarmType(alarmType)
                     .build();
-            UserDisabledAlarm saveUserDisabledAlarm = userDisabledAlarmRepository.save(userDisabledAlarm);
-            return PatchDisableAlarmResponse.of(saveUserDisabledAlarm, true);
+            toCreate.add(userDisabledAlarm);
         }
 
-        UserDisabledAlarm userDisabledAlarm = optional.get();
-        userDisabledAlarmRepository.delete(userDisabledAlarm);
-        return PatchDisableAlarmResponse.of(userDisabledAlarm, false);
+        if (!toCreate.isEmpty()) {
+            userDisabledAlarmRepository.saveAll(toCreate);
+        }
+        if (!toDelete.isEmpty()) {
+            userDisabledAlarmRepository.deleteAll(toDelete);
+        }
+
+        return PatchDisableAlarmResponse.of(toCreate, toDelete);
     }
 
     public GetAlarmDisableResponse findDisableAlarm(CustomUserDetails userDetails) {

--- a/src/main/java/ku_rum/backend/domain/alarm/application/AlarmService.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/application/AlarmService.java
@@ -178,7 +178,7 @@ public class AlarmService {
             userDisabledAlarmRepository.deleteAll(toDelete);
         }
 
-        return PatchDisableAlarmResponse.of(toCreate, toDelete);
+        return PatchDisableAlarmResponse.of(user.getId(), toCreate, toDelete);
     }
 
     public GetAlarmDisableResponse findDisableAlarm(CustomUserDetails userDetails) {

--- a/src/main/java/ku_rum/backend/domain/alarm/domain/repository/UserDisabledAlarmRepository.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/domain/repository/UserDisabledAlarmRepository.java
@@ -13,5 +13,7 @@ public interface UserDisabledAlarmRepository extends JpaRepository<UserDisabledA
 
     Optional<UserDisabledAlarm> findByUserAndAlarmType(User user, AlarmType alarmType);
 
+    List<UserDisabledAlarm> findByUserAndAlarmTypeIn(User user, List<AlarmType> alarmTypes);
+
     List<UserDisabledAlarm> findByUser(User user);
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/dto/request/PatchDisableAlarmRequest.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/dto/request/PatchDisableAlarmRequest.java
@@ -1,6 +1,7 @@
 package ku_rum.backend.domain.alarm.dto.request;
 
+import java.util.List;
 import ku_rum.backend.domain.alarm.domain.AlarmType;
 
-public record PatchDisableAlarmRequest(AlarmType alarmType) {
+public record PatchDisableAlarmRequest(List<AlarmType> alarmTypes) {
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/dto/response/DisableAlarmDto.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/dto/response/DisableAlarmDto.java
@@ -1,0 +1,10 @@
+package ku_rum.backend.domain.alarm.dto.response;
+
+import ku_rum.backend.domain.alarm.domain.AlarmType;
+import ku_rum.backend.domain.alarm.domain.UserDisabledAlarm;
+
+public record DisableAlarmDto(AlarmType alarmType, Boolean isDisabled) {
+    public static DisableAlarmDto of(UserDisabledAlarm userDisabledAlarm, boolean isDisabled) {
+        return new DisableAlarmDto(userDisabledAlarm.getAlarmType(), isDisabled);
+    }
+}

--- a/src/main/java/ku_rum/backend/domain/alarm/dto/response/PatchDisableAlarmResponse.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/dto/response/PatchDisableAlarmResponse.java
@@ -1,11 +1,30 @@
 package ku_rum.backend.domain.alarm.dto.response;
 
-import ku_rum.backend.domain.alarm.domain.AlarmType;
+import java.util.ArrayList;
+import java.util.List;
 import ku_rum.backend.domain.alarm.domain.UserDisabledAlarm;
 
-public record PatchDisableAlarmResponse(Long userId, AlarmType alarmType, Boolean isDisabled) {
-    public static PatchDisableAlarmResponse of(UserDisabledAlarm userDisabledAlarm, boolean isDisabled) {
-        return new PatchDisableAlarmResponse(userDisabledAlarm.getUser().getId(), userDisabledAlarm.getAlarmType(),
-                isDisabled);
+public record PatchDisableAlarmResponse(Long userId, List<DisableAlarmDto> alarms) {
+    public static PatchDisableAlarmResponse of(List<UserDisabledAlarm> toCreate, List<UserDisabledAlarm> toDelete) {
+        Long userId = null;
+        if (!toCreate.isEmpty()) {
+            userId = toCreate.get(0).getUser().getId();
+        } else if (!toDelete.isEmpty()) {
+            userId = toDelete.get(0).getUser().getId();
+        }
+
+        List<DisableAlarmDto> createdAlarms = toCreate.stream()
+                .map(userDisabledAlarm -> DisableAlarmDto.of(userDisabledAlarm, false))
+                .toList();
+
+        List<DisableAlarmDto> deletedAlarms = toDelete.stream()
+                .map(userDisabledAlarm -> DisableAlarmDto.of(userDisabledAlarm, true))
+                .toList();
+
+        List<DisableAlarmDto> allAlarms = new ArrayList<>();
+        allAlarms.addAll(createdAlarms);
+        allAlarms.addAll(deletedAlarms);
+
+        return new PatchDisableAlarmResponse(userId, allAlarms);
     }
 }

--- a/src/main/java/ku_rum/backend/domain/alarm/dto/response/PatchDisableAlarmResponse.java
+++ b/src/main/java/ku_rum/backend/domain/alarm/dto/response/PatchDisableAlarmResponse.java
@@ -5,20 +5,15 @@ import java.util.List;
 import ku_rum.backend.domain.alarm.domain.UserDisabledAlarm;
 
 public record PatchDisableAlarmResponse(Long userId, List<DisableAlarmDto> alarms) {
-    public static PatchDisableAlarmResponse of(List<UserDisabledAlarm> toCreate, List<UserDisabledAlarm> toDelete) {
-        Long userId = null;
-        if (!toCreate.isEmpty()) {
-            userId = toCreate.get(0).getUser().getId();
-        } else if (!toDelete.isEmpty()) {
-            userId = toDelete.get(0).getUser().getId();
-        }
+    public static PatchDisableAlarmResponse of(Long userId, List<UserDisabledAlarm> toCreate,
+                                               List<UserDisabledAlarm> toDelete) {
 
         List<DisableAlarmDto> createdAlarms = toCreate.stream()
-                .map(userDisabledAlarm -> DisableAlarmDto.of(userDisabledAlarm, false))
+                .map(userDisabledAlarm -> DisableAlarmDto.of(userDisabledAlarm, true))
                 .toList();
 
         List<DisableAlarmDto> deletedAlarms = toDelete.stream()
-                .map(userDisabledAlarm -> DisableAlarmDto.of(userDisabledAlarm, true))
+                .map(userDisabledAlarm -> DisableAlarmDto.of(userDisabledAlarm, false))
                 .toList();
 
         List<DisableAlarmDto> allAlarms = new ArrayList<>();

--- a/src/test/java/ku_rum/backend/domain/alarm/presentation/AlarmControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/alarm/presentation/AlarmControllerTest.java
@@ -238,7 +238,6 @@ public class AlarmControllerTest extends RestDocsTestSupport {
                                         fieldWithPath("data.userId").description("유저 ID"),
                                         fieldWithPath("data.alarms[].alarmType").description("알람 타입"),
                                         fieldWithPath("data.alarms[].isDisabled").description("활성 여부")
-                                        //fieldWithPath("data.isDisabled").description("활성화 비활성화 여부")
                                 )
                                 .build()
                 )));

--- a/src/test/java/ku_rum/backend/domain/alarm/presentation/AlarmControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/alarm/presentation/AlarmControllerTest.java
@@ -25,6 +25,7 @@ import ku_rum.backend.domain.alarm.domain.AlarmType;
 import ku_rum.backend.domain.alarm.dto.request.PatchAlarmRequest;
 import ku_rum.backend.domain.alarm.dto.request.PatchDisableAlarmRequest;
 import ku_rum.backend.domain.alarm.dto.response.AlarmPaginationRequest;
+import ku_rum.backend.domain.alarm.dto.response.DisableAlarmDto;
 import ku_rum.backend.domain.alarm.dto.response.GetAlarmDisableResponse;
 import ku_rum.backend.domain.alarm.dto.response.GetAlarmDto;
 import ku_rum.backend.domain.alarm.dto.response.GetAlarmResponse;
@@ -201,10 +202,10 @@ public class AlarmControllerTest extends RestDocsTestSupport {
     void patchDisableAlarm() throws Exception {
 
         // given
-        PatchDisableAlarmResponse response = new PatchDisableAlarmResponse(1L, AlarmType.NEW_NOTICE,
-                Boolean.valueOf(true));
+        DisableAlarmDto disableAlarmDto = new DisableAlarmDto(AlarmType.NEW_NOTICE, true);
+        PatchDisableAlarmResponse response = new PatchDisableAlarmResponse(1L, List.of(disableAlarmDto));
 
-        PatchDisableAlarmRequest request = new PatchDisableAlarmRequest(AlarmType.NEW_NOTICE);
+        PatchDisableAlarmRequest request = new PatchDisableAlarmRequest(List.of(AlarmType.NEW_NOTICE));
         given(alarmService.disableAlarm(any(), eq(request)))
                 .willReturn(response);
 
@@ -214,15 +215,15 @@ public class AlarmControllerTest extends RestDocsTestSupport {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "alarmType": "NEW_NOTICE"
+                                  "alarmTypes": ["NEW_NOTICE"]
                                 }
                                 """))
                 // then
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.userId").value(1))
-                .andExpect(jsonPath("$.data.alarmType").value("NEW_NOTICE"))
-                .andExpect(jsonPath("$.data.isDisabled").value(true))
+                .andExpect(jsonPath("$.data.alarms[0].alarmType").value("NEW_NOTICE"))
+                .andExpect(jsonPath("$.data.alarms[0].isDisabled").value(true))
                 .andDo(restDocs.document(resource(
                         ResourceSnippetParameters.builder()
                                 .tag("알림 조회 API")
@@ -235,8 +236,9 @@ public class AlarmControllerTest extends RestDocsTestSupport {
                                         fieldWithPath("status").description("응답 상태"),
                                         fieldWithPath("message").description("응답 메시지"),
                                         fieldWithPath("data.userId").description("유저 ID"),
-                                        fieldWithPath("data.alarmType").description("알람 타입"),
-                                        fieldWithPath("data.isDisabled").description("활성화 비활성화 여부")
+                                        fieldWithPath("data.alarms[].alarmType").description("알람 타입"),
+                                        fieldWithPath("data.alarms[].isDisabled").description("활성 여부")
+                                        //fieldWithPath("data.isDisabled").description("활성화 비활성화 여부")
                                 )
                                 .build()
                 )));
@@ -250,7 +252,6 @@ public class AlarmControllerTest extends RestDocsTestSupport {
         GetAlarmDisableResponse response = new GetAlarmDisableResponse(
                 List.of(AlarmType.NEW_NOTICE, AlarmType.NEW_KEYWORD_NOTICE));
 
-        PatchDisableAlarmRequest request = new PatchDisableAlarmRequest(AlarmType.NEW_NOTICE);
         given(alarmService.findDisableAlarm(any()))
                 .willReturn(response);
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closes #375 

## 📝작업 내용
- [x] 알림 비활성화/활성화 API 변경

## 작업 상세 내용
- 배열로 변경
- DB 벌크 save, delete

## 💬리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새 기능**
  * 알람 비활성화를 여러 알람 타입에 대해 일괄 처리할 수 있도록 개선되었습니다.
  * 요청/응답 형식이 목록 기반으로 변경되어 한 번에 여러 알람의 상태(isDisabled)를 반환/조정합니다.

* **테스트**
  * 관련 단위/통합 테스트가 목록 기반 입력·출력에 맞게 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->