### PR TITLE
[Feat] 지도 검색 API 분리

### DIFF
--- a/src/main/java/ku_rum/backend/domain/place/application/PlaceService.java
+++ b/src/main/java/ku_rum/backend/domain/place/application/PlaceService.java
@@ -125,19 +125,6 @@ public class PlaceService {
     }
 
     /**
-     * 장소 검색(회원 로직)
-     *
-     * @param userDetails
-     * @param query
-     * @return
-     */
-    @Transactional
-    public List<SearchPlaceResponse> searchPlaceWithUser(CustomUserDetails userDetails, String query) {
-        placeHistoryService.updatePlaceHistory(query, userDetails);
-        return searchPlace(query);
-    }
-
-    /**
      * place 조회
      *
      * @param placeId

--- a/src/main/java/ku_rum/backend/domain/place/presentation/PlaceController.java
+++ b/src/main/java/ku_rum/backend/domain/place/presentation/PlaceController.java
@@ -105,11 +105,17 @@ public class PlaceController {
     @GetMapping("/search")
     public BaseResponse<List<SearchPlaceResponse>> searchPlace(@RequestParam("query") String query,
                                                                @AuthenticationPrincipal final CustomUserDetails userDetails) {
-        if (isAuthenticated(userDetails)) {
-            return BaseResponse.ok(placeService.searchPlaceWithUser(userDetails, query));
-        }
         return BaseResponse.ok(placeService.searchPlace(query));
     }
+
+    @PostMapping("/search/keyword")
+    public BaseResponse<Void> getPlaceSearchKeyword(@RequestParam("query") String query,
+                                                    @AuthenticationPrincipal final CustomUserDetails userDetails) {
+
+        placeHistoryService.updatePlaceHistory(query, userDetails);
+        return BaseResponse.ok();
+    }
+
 
     @GetMapping("/search/history")
     public BaseResponse<List<SearchPlaceHistoryResponse>> searchPlaceHistory(

--- a/src/main/java/ku_rum/backend/domain/user/presentation/UserProfileController.java
+++ b/src/main/java/ku_rum/backend/domain/user/presentation/UserProfileController.java
@@ -47,17 +47,6 @@ public class UserProfileController {
     }
 
     /**
-     * 프로필 조회 API
-     *
-     * @return
-     */
-    @GetMapping("/profile")
-    public BaseResponse<UserProfileResponse> getUserProfile() {
-        UserProfileResponse response = userService.getUserProfile();
-        return BaseResponse.ok(response);
-    }
-
-    /**
      * 프로필 변경 API
      *
      * @param profileChangeRequest

--- a/src/test/java/ku_rum/backend/domain/department/presentation/DepartmentQueryControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/department/presentation/DepartmentQueryControllerTest.java
@@ -158,7 +158,7 @@ class DepartmentQueryControllerTest extends RestDocsTestSupport {
                         resource(
                                 ResourceSnippetParameters.builder()
                                         .tag("학과 관련 API")
-                                        .description("학과 검색")
+                                        .description("학과 URL 확인")
                                         .responseFields(
                                                 fieldWithPath("code")
                                                         .type(JsonFieldType.NUMBER)

--- a/src/test/java/ku_rum/backend/domain/place/presentation/PlaceControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/place/presentation/PlaceControllerTest.java
@@ -359,6 +359,45 @@ public class PlaceControllerTest extends RestDocsTestSupport {
 
     }
 
+    @DisplayName("장소 검색어를 저장한다")
+    @Test
+    void savePlaceSearchKeyword() throws Exception {
+        //given
+        doNothing().when(placeHistoryService).updatePlaceHistory(any(), any());
+
+        //when
+        mockMvc.perform(post("/api/v1/places/search/keyword")
+                        .queryParam("query", "검색어")
+                        .header("Authorization",
+                                "access-token"))
+                //then
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("지도 관련 API")
+                                .description("지도 검색어 저장")
+                                .requestHeaders(
+                                        headerWithName("Authorization").description("발급 받은 엑세스 토큰입니다.")
+                                )
+                                .queryParameters(
+                                        RequestDocumentation.parameterWithName("query").description("검색어")
+                                )
+                                .responseFields(
+                                        fieldWithPath("code")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("응답 코드 (200)"),
+                                        fieldWithPath("status")
+                                                .type(JsonFieldType.STRING)
+                                                .description("응답 상태 (OK)"),
+                                        fieldWithPath("message")
+                                                .type(JsonFieldType.STRING)
+                                                .description("응답 메시지")
+                                )
+                                .build())));
+
+    }
+
     @DisplayName("장소 검색 기록를 확인한다")
     @Test
     void searchPlaceHistory() throws Exception {

--- a/src/test/java/ku_rum/backend/domain/place/presentation/PlaceControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/place/presentation/PlaceControllerTest.java
@@ -316,8 +316,7 @@ public class PlaceControllerTest extends RestDocsTestSupport {
         //when
         mockMvc.perform(get("/api/v1/places/search")
                         .param("query", query)
-                        .header("Authorization",
-                                "access-token"))
+                        .header("Authorization", "Bearer test-access-token"))
                 //then
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -369,7 +368,7 @@ public class PlaceControllerTest extends RestDocsTestSupport {
         mockMvc.perform(post("/api/v1/places/search/keyword")
                         .queryParam("query", "검색어")
                         .header("Authorization",
-                                "access-token"))
+                                "Bearer test-access-token"))
                 //then
                 .andDo(print())
                 .andExpect(status().isOk())

--- a/src/test/java/ku_rum/backend/domain/place/presentation/PlaceControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/place/presentation/PlaceControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.headerWit
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -28,6 +29,7 @@ import ku_rum.backend.domain.place.application.response.CurrentPositionResponse;
 import ku_rum.backend.domain.place.application.response.CurrentPositionStatusResponse;
 import ku_rum.backend.domain.place.application.response.GetPlaceResponse;
 import ku_rum.backend.domain.place.application.response.SearchPlaceHistoryResponse;
+import ku_rum.backend.domain.place.application.response.SearchPlaceResponse;
 import ku_rum.backend.domain.place.application.response.SelectPlaceChipResponse;
 import ku_rum.backend.domain.place.domain.CategoryChip;
 import ku_rum.backend.domain.place.domain.Place;
@@ -44,6 +46,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.restdocs.request.RequestDocumentation;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -282,6 +285,75 @@ public class PlaceControllerTest extends RestDocsTestSupport {
                                 )
                                 .pathParameters(
                                         RequestDocumentation.parameterWithName("placeId").description("건물id")
+                                )
+                                .build())));
+
+    }
+
+    @DisplayName("장소를 검색한다")
+    @Test
+    void searchPlace() throws Exception {
+        //given
+        String query = "도서관";
+        String name = "상허기념도서관";
+        Long placeId = 1L;
+        Place place = Place.builder()
+                .placeId(placeId)
+                .categoryChip(CategoryChip.K_CUBE)
+                .name(name)
+                .subName("상허기념도서관 K-CUBE")
+                .content("상허기념도서관 K-CUBE입니다")
+                .latitude(BigDecimal.valueOf(37.541941000))
+                .longitude(BigDecimal.valueOf(127.073784000))
+                .build();
+
+        List<SearchPlaceResponse> responses = List.of(
+                new SearchPlaceResponse(name, placeId, BigDecimal.valueOf(123.1), BigDecimal.valueOf(123.1)));
+
+        given(placeService.searchPlace(eq(query)))
+                .willReturn(responses);
+
+        //when
+        mockMvc.perform(get("/api/v1/places/search")
+                        .param("query", query)
+                        .header("Authorization",
+                                "access-token"))
+                //then
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].name").value(name))
+                .andDo(restDocs.document(resource(
+                        ResourceSnippetParameters.builder()
+                                .tag("지도 관련 API")
+                                .description("지도 검색")
+                                .requestHeaders(
+                                        headerWithName("Authorization").description("발급 받은 엑세스 토큰입니다.")
+                                )
+                                .queryParameters(
+                                        RequestDocumentation.parameterWithName("query").description("검색어")
+                                )
+                                .responseFields(
+                                        fieldWithPath("code")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("응답 코드 (200)"),
+                                        fieldWithPath("status")
+                                                .type(JsonFieldType.STRING)
+                                                .description("응답 상태 (OK)"),
+                                        fieldWithPath("message")
+                                                .type(JsonFieldType.STRING)
+                                                .description("응답 메시지"),
+                                        fieldWithPath("data[].name")
+                                                .type(JsonFieldType.STRING)
+                                                .description("장소 이름"),
+                                        fieldWithPath("data[].placeId")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("장소 ID"),
+                                        fieldWithPath("data[].latitude")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("장소 위도"),
+                                        fieldWithPath("data[].longitude")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("장소 경도")
                                 )
                                 .build())));
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
closes #399 

## 📝작업 내용
- [x] 지도 검색 API 분리
- [x] #397 에 잘못된 API명세서 수정
- [x] 누락된 테스트 추가(지도 검색 테스트) 

## 작업 상세 내용
실시간 처리를 위한 지도 검색어 저장 API 분리

## 💬리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 장소 검색 키워드를 기록하는 새 API 엔드포인트 추가 (POST /api/v1/places/search/keyword)

* **개선 사항**
  * 장소 검색 엔드포인트 단순화 — 사용자 인증 여부와 상관없이 동일한 검색 경로 사용

* **테스트**
  * 장소 검색 및 키워드 저장에 대한 테스트 케이스 및 문서화 추가
  * 학과 관련 API 응답 설명 문구 업데이트

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->