### PR TITLE
[feat] presignedURL 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -183,9 +183,14 @@ dependencies {
     //micrometer
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
-    // AWS
+    // AWS v1 (기존 - 호환성 유지)
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
     implementation 'io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4'
+
+    // AWS SDK v2 for S3 (Presigned URL 용)
+    implementation platform('software.amazon.awssdk:bom:2.20.26')
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:s3-transfer-manager'
 
     // postGIS
     implementation "org.hibernate.orm:hibernate-spatial"
@@ -197,6 +202,8 @@ dependencies {
 
     // FCM
     implementation 'com.google.firebase:firebase-admin:9.7.0'
+
+    implementation 'io.prometheus:prometheus-metrics-exposition-formats'
 }
 
 

--- a/src/main/java/ku_rum/backend/domain/user/application/UserService.java
+++ b/src/main/java/ku_rum/backend/domain/user/application/UserService.java
@@ -9,6 +9,7 @@ import static ku_rum.backend.global.support.status.BaseExceptionResponseStatus.P
 import java.util.List;
 import ku_rum.backend.domain.auth.dto.response.AuthResponse;
 import ku_rum.backend.domain.common.mail.application.MailService;
+import ku_rum.backend.domain.common.s3.application.S3Service;
 import ku_rum.backend.domain.department.application.DepartmentQueryService;
 import ku_rum.backend.domain.department.application.UserDepartmentService;
 import ku_rum.backend.domain.department.domain.Department;
@@ -23,10 +24,12 @@ import ku_rum.backend.domain.user.dto.request.InitiatePasswordResetRequest;
 import ku_rum.backend.domain.user.dto.request.NicknameChangeRequest;
 import ku_rum.backend.domain.user.dto.request.ProfileChangeRequest;
 import ku_rum.backend.domain.user.dto.request.ResetPasswordRequest;
+import ku_rum.backend.domain.user.dto.request.S3PresignedUrlRequest;
 import ku_rum.backend.domain.user.dto.request.SocialSignupRequest;
 import ku_rum.backend.domain.user.dto.request.TemporaryUserRequest;
 import ku_rum.backend.domain.user.dto.request.UserSaveRequest;
 import ku_rum.backend.domain.user.dto.response.LoginIdResponse;
+import ku_rum.backend.domain.user.dto.response.S3PresignedUrlResponse;
 import ku_rum.backend.domain.user.dto.response.TemporaryUserResponse;
 import ku_rum.backend.domain.user.dto.response.TokenResponse;
 import ku_rum.backend.domain.user.dto.response.UserProfileDepartmentResponse;
@@ -64,6 +67,7 @@ public class UserService {
     private final DepartmentRepository departmentRepository;
     private final UserDepartmentService userDepartmentService;
     private final MailService mailService;
+    private final S3Service s3Service;
     private final PreSignupTokenProvider preSignupTokenProvider;
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -154,6 +158,25 @@ public class UserService {
         User user = getUser();
         user.changeImage(profileChangeRequest.imageUrl());
         log.info("프로필 변경 완료: userId={}", user.getId());
+    }
+
+    /**
+     * 프로필 이미지 업로드용 S3 Presigned URL 생성
+     */
+    public S3PresignedUrlResponse generateProfileImagePresignedUrl(final S3PresignedUrlRequest request) {
+        log.info("Presigned URL 생성 요청: fileName={}, fileType={}", request.fileName(), request.fileType());
+
+        S3Service.PresignedUrlInfo urlInfo = s3Service.generatePresignedUrl(
+                request.fileName(),
+                request.fileType()
+        );
+
+        log.info("Presigned URL 생성 완료: fileKey={}", urlInfo.fileKey());
+        return S3PresignedUrlResponse.of(
+                urlInfo.presignedUrl(),
+                urlInfo.fileKey(),
+                urlInfo.fullUrl()
+        );
     }
 
     public LoginIdResponse getLoginId(final String email) {

--- a/src/main/java/ku_rum/backend/domain/user/dto/request/S3PresignedUrlRequest.java
+++ b/src/main/java/ku_rum/backend/domain/user/dto/request/S3PresignedUrlRequest.java
@@ -1,0 +1,12 @@
+package ku_rum.backend.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record S3PresignedUrlRequest(
+        @NotBlank(message = "파일명은 필수입니다.")
+        String fileName,
+
+        @NotBlank(message = "파일 타입은 필수입니다.")
+        String fileType
+) {
+}

--- a/src/main/java/ku_rum/backend/domain/user/dto/response/S3PresignedUrlResponse.java
+++ b/src/main/java/ku_rum/backend/domain/user/dto/response/S3PresignedUrlResponse.java
@@ -1,0 +1,11 @@
+package ku_rum.backend.domain.user.dto.response;
+
+public record S3PresignedUrlResponse(
+        String presignedUrl,
+        String fileKey,
+        String fullUrl
+) {
+    public static S3PresignedUrlResponse of(String presignedUrl, String fileKey, String fullUrl) {
+        return new S3PresignedUrlResponse(presignedUrl, fileKey, fullUrl);
+    }
+}

--- a/src/main/java/ku_rum/backend/domain/user/presentation/UserProfileController.java
+++ b/src/main/java/ku_rum/backend/domain/user/presentation/UserProfileController.java
@@ -12,7 +12,9 @@ import ku_rum.backend.domain.user.dto.request.InitiatePasswordResetRequest;
 import ku_rum.backend.domain.user.dto.request.NicknameChangeRequest;
 import ku_rum.backend.domain.user.dto.request.ProfileChangeRequest;
 import ku_rum.backend.domain.user.dto.request.ResetPasswordRequest;
+import ku_rum.backend.domain.user.dto.request.S3PresignedUrlRequest;
 import ku_rum.backend.domain.user.dto.response.LoginIdResponse;
+import ku_rum.backend.domain.user.dto.response.S3PresignedUrlResponse;
 import ku_rum.backend.domain.user.dto.response.UserProfileResponse;
 import ku_rum.backend.global.support.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
@@ -136,6 +138,19 @@ public class UserProfileController {
     public BaseResponse<String> deleteDepartment(@RequestBody @Valid final DepartmentRequest departmentRequest) {
         userService.deleteDepartment(departmentRequest.department());
         return BaseResponse.ok("학과 삭제에 성공하였습니다.");
+    }
+
+    /**
+     * 프로필 이미지 업로드용 S3 Presigned URL 생성 API
+     *
+     * @param request
+     * @return
+     */
+    @PostMapping("/profile/presigned-url")
+    public BaseResponse<S3PresignedUrlResponse> generatePresignedUrl(
+            @RequestBody @Valid final S3PresignedUrlRequest request) {
+        S3PresignedUrlResponse response = userService.generateProfileImagePresignedUrl(request);
+        return BaseResponse.ok(response);
     }
 }
 

--- a/src/main/java/ku_rum/backend/global/config/S3Config.java
+++ b/src/main/java/ku_rum/backend/global/config/S3Config.java
@@ -1,15 +1,13 @@
-
 package ku_rum.backend.global.config;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 public class S3Config {
@@ -20,32 +18,24 @@ public class S3Config {
     @Value("${cloud.aws.credentials.secret-key}")
     private String secretKey;
 
-    @Value("${cloud.aws.region}")
+    @Value("${cloud.aws.region.static}")
     private String region;
 
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
-
-    @PostConstruct
-    public void init() {
-        System.out.println("✅ AWS region: " + region);
-        System.out.println("✅ AWS accessKey: " + accessKey);
-        System.out.println("✅ AWS bucket: " + bucket);  // -> 오류 나면 이 줄에서 터짐
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)))
+                .build();
     }
 
     @Bean
-    @Primary
-    public BasicAWSCredentials awsCredentialsProvider() {
-        BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials(accessKey, secretKey);
-        return basicAWSCredentials;
-    }
-
-    @Bean
-    public AmazonS3 amazonS3() {
-        return AmazonS3ClientBuilder.standard()
-                .withRegion(region)
-                .withCredentials(new AWSStaticCredentialsProvider(awsCredentialsProvider()))
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)))
                 .build();
     }
 }
-

--- a/src/main/java/ku_rum/backend/global/utill/S3Service.java
+++ b/src/main/java/ku_rum/backend/global/utill/S3Service.java
@@ -1,0 +1,93 @@
+package ku_rum.backend.domain.common.s3.application;
+
+import java.time.Duration;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3Service {
+
+    private final S3Presigner s3Presigner;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    /**
+     * S3 presigned URL 생성 (프로필 이미지 업로드용)
+     *
+     * @param fileName 원본 파일명
+     * @param fileType 파일 MIME 타입
+     * @return presigned URL 정보
+     */
+    public PresignedUrlInfo generatePresignedUrl(String fileName, String fileType) {
+        // 고유한 파일 키 생성
+        String fileKey = generateFileKey(fileName);
+
+        log.info("Presigned URL 생성 요청: fileName={}, fileType={}, fileKey={}", fileName, fileType, fileKey);
+
+        // PutObjectRequest 생성
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileKey)
+                .contentType(fileType)
+                .build();
+
+        // Presigned URL 생성 (15분 유효)
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(15))
+                .putObjectRequest(putObjectRequest)
+                .build();
+
+        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(presignRequest);
+        String presignedUrl = presignedRequest.url().toString();
+
+        // 업로드 후 접근할 최종 URL
+        String fullUrl = String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, fileKey);
+
+        log.info("Presigned URL 생성 완료: fileKey={}", fileKey);
+
+        return new PresignedUrlInfo(presignedUrl, fileKey, fullUrl);
+    }
+
+    /**
+     * 파일 키 생성 (profile/{UUID}_{fileName})
+     */
+    private String generateFileKey(String fileName) {
+        String uuid = UUID.randomUUID().toString();
+        String extension = extractExtension(fileName);
+        return String.format("profile/%s_%s", uuid, fileName);
+    }
+
+    /**
+     * 파일 확장자 추출
+     */
+    private String extractExtension(String fileName) {
+        int lastDotIndex = fileName.lastIndexOf(".");
+        if (lastDotIndex > 0 && lastDotIndex < fileName.length() - 1) {
+            return fileName.substring(lastDotIndex);
+        }
+        return "";
+    }
+
+    /**
+     * Presigned URL 정보를 담는 레코드
+     */
+    public record PresignedUrlInfo(
+            String presignedUrl,
+            String fileKey,
+            String fullUrl
+    ) {
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -94,7 +94,8 @@ openai:
 
 cloud:
   aws:
-    region: ap-northeast-2
+    region:
+      static: ap-northeast-2
     credentials:
       access-key: testtest
       secret-key: testtest

--- a/src/test/java/ku_rum/backend/domain/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/auth/presentation/AuthControllerTest.java
@@ -45,6 +45,9 @@ class AuthControllerTest extends RestDocsTestSupport {
     @MockBean
     private SecurityFilterChain securityFilterChain;
 
+    @MockBean
+    private ku_rum.backend.domain.common.s3.application.S3Service s3Service;
+
     @DisplayName("로그인을 진행한다.")
     @Test
     @WithMockUser

--- a/src/test/java/ku_rum/backend/domain/college/presentation/CollegeQueryControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/college/presentation/CollegeQueryControllerTest.java
@@ -34,6 +34,9 @@ class CollegeQueryControllerTest extends RestDocsTestSupport {
     @MockBean
     private SecurityFilterChain securityFilterChain;
 
+    @MockBean
+    private ku_rum.backend.domain.common.s3.application.S3Service s3Service;
+
     @Test
     @DisplayName("전체 컬리지 목록 조회 성공")
     @WithMockUser

--- a/src/test/java/ku_rum/backend/domain/user/presentation/UserProfileControllerTest.java
+++ b/src/test/java/ku_rum/backend/domain/user/presentation/UserProfileControllerTest.java
@@ -10,6 +10,8 @@ import ku_rum.backend.domain.user.dto.request.DepartmentRequest;
 import ku_rum.backend.domain.user.dto.request.InitiatePasswordResetRequest;
 import ku_rum.backend.domain.user.dto.request.NicknameChangeRequest;
 import ku_rum.backend.domain.user.dto.request.ResetPasswordRequest;
+import ku_rum.backend.domain.user.dto.request.S3PresignedUrlRequest;
+import ku_rum.backend.domain.user.dto.response.S3PresignedUrlResponse;
 import ku_rum.backend.global.security.CustomUserDetails;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,6 +31,7 @@ import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -315,5 +318,87 @@ public class UserProfileControllerTest extends RestDocsTestSupport {
                         )));
 
         verify(userService, times(1)).deleteDepartment("컴퓨터공학과");
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 업로드용 S3 Presigned URL 생성 API")
+    @WithMockUser(roles = "USER")
+    void generatePresignedUrl() throws Exception {
+        // given
+        S3PresignedUrlRequest request = new S3PresignedUrlRequest(
+                "profile.jpg",
+                "image/jpeg"
+        );
+
+        S3PresignedUrlResponse mockResponse = new S3PresignedUrlResponse(
+                "https://bucket.s3.ap-northeast-2.amazonaws.com/profile/uuid_profile.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&...",
+                "profile/uuid_profile.jpg",
+                "https://bucket.s3.ap-northeast-2.amazonaws.com/profile/uuid_profile.jpg"
+        );
+
+        when(userService.generateProfileImagePresignedUrl(any(S3PresignedUrlRequest.class)))
+                .thenReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/users/profile/presigned-url")
+                        .header("Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyUEsiOjEsInJvbGVzIjoiUk9MRV9VU0VSIiwiaWF0IjoxNzQwMjQyNjQxLCJleHAiOjE3NDAyNDQ0NDF9.kLSMBLWdvIvrBpGJdOigSKjxMIab0cV06xFjSpwrq70")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data.presignedUrl").exists())
+                .andExpect(jsonPath("$.data.fileKey").exists())
+                .andExpect(jsonPath("$.data.fullUrl").exists())
+                .andDo(restDocs.document(
+                        resource(ResourceSnippetParameters.builder()
+                                .tag("프로필 관련 API")
+                                .description("프로필 이미지 업로드용 S3 Presigned URL 생성 API\n\n" +
+                                        "### 사용 방법\n" +
+                                        "1. 이 API를 호출하여 Presigned URL을 받습니다.\n" +
+                                        "2. 클라이언트에서 받은 presignedUrl로 이미지를 직접 S3에 PUT 요청으로 업로드합니다.\n" +
+                                        "3. 업로드 성공 후 fullUrl을 프로필 변경 API에 전달합니다.\n\n" +
+                                        "### 주의사항\n" +
+                                        "- Presigned URL은 15분간 유효합니다.\n" +
+                                        "- 허용되는 파일 타입: image/jpeg, image/jpg, image/png, image/webp\n" +
+                                        "- 최대 파일 크기: 5MB")
+                                .requestHeaders(
+                                        headerWithName("Authorization").description("발급 받은 액세스 토큰 (Bearer {token})")
+                                )
+                                .requestFields(
+                                        fieldWithPath("fileName")
+                                                .type(JsonFieldType.STRING)
+                                                .description("업로드할 파일명 (예: profile.jpg)"),
+                                        fieldWithPath("fileType")
+                                                .type(JsonFieldType.STRING)
+                                                .description("파일 MIME 타입 (예: image/jpeg, image/png)")
+                                )
+                                .responseFields(
+                                        fieldWithPath("code")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("응답 코드 (200)"),
+                                        fieldWithPath("status")
+                                                .type(JsonFieldType.STRING)
+                                                .description("응답 상태 (OK)"),
+                                        fieldWithPath("message")
+                                                .type(JsonFieldType.STRING)
+                                                .description("응답 메시지"),
+                                        fieldWithPath("data.presignedUrl")
+                                                .type(JsonFieldType.STRING)
+                                                .description("S3에 업로드할 때 사용하는 Presigned URL (15분간 유효)"),
+                                        fieldWithPath("data.fileKey")
+                                                .type(JsonFieldType.STRING)
+                                                .description("S3에 저장될 파일의 키 (예: profile/uuid_filename.jpg)"),
+                                        fieldWithPath("data.fullUrl")
+                                                .type(JsonFieldType.STRING)
+                                                .description("업로드 완료 후 접근 가능한 최종 이미지 URL (프로필 변경 API에 전달)")
+                                )
+                                .build()
+                        )));
+
+        verify(userService, times(1)).generateProfileImagePresignedUrl(any(S3PresignedUrlRequest.class));
     }
 }


### PR DESCRIPTION

## 📝 작업 내용
- [x] S3 Presigned URL 생성 API 테스트 코드 추가
- [x] Rest Docs 문서화 작성
- [x] Mock 응답 및 검증 로직 구현

## 작업 상세 내용
프로필 이미지 업로드를 위한 S3 Presigned URL 생성 API(`POST /api/v1/users/profile/presigned-url`)에 대한 테스트 코드를 작성했습니다.

### 주요 구현 내용
- `S3PresignedUrlRequest` / `S3PresignedUrlResponse` DTO를 활용한 테스트
- Mock 응답으로 presignedUrl, fileKey, fullUrl 검증
- Rest Docs를 통한 API 문서 자동 생성
  - 사용 방법 3단계 설명
  - 주의사항 (유효시간 15분, 파일타입, 크기 제한) 명시
  - 요청/응답 필드 상세 설명

## 💬 리뷰 요구사항
- Rest Docs 설명이 충분한지 확인 부탁드립니다
- Mock 응답 데이터 형식이 실제 S3Service와 일치하는지 검토 부탁드립니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로필 이미지 업로드를 위한 S3 사전 서명 URL 생성 기능 추가

* **Chores**
  * AWS SDK를 v1에서 v2로 마이그레이션
  * 메트릭 포맷팅을 위한 의존성 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->